### PR TITLE
Allow shell glob patters for label/annotation keys.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,12 @@
 # Labels to be propagated to sub-namespaces.
+# It is also possible to specify a glob pattern that can be interpreted by Go's "filepath.Match" func.
+# https://pkg.go.dev/path/filepath#Match
 labelKeys:
 - team
 
 # Annotations to be propagated to sub-namespaces.
+# It is also possible to specify a glob pattern that can be interpreted by Go's "filepath.Match" func.
+# https://pkg.go.dev/path/filepath#Match
 annotationKeys:
 # An example to propagate an annotation for MetalLB
 # https://metallb.universe.tf/usage/#requesting-specific-ips

--- a/config.yaml
+++ b/config.yaml
@@ -1,12 +1,12 @@
 # Labels to be propagated to sub-namespaces.
-# It is also possible to specify a glob pattern that can be interpreted by Go's "filepath.Match" func.
-# https://pkg.go.dev/path/filepath#Match
+# It is also possible to specify a glob pattern that can be interpreted by Go's "path.Match" func.
+# https://pkg.go.dev/path#Match
 labelKeys:
 - team
 
 # Annotations to be propagated to sub-namespaces.
-# It is also possible to specify a glob pattern that can be interpreted by Go's "filepath.Match" func.
-# https://pkg.go.dev/path/filepath#Match
+# It is also possible to specify a glob pattern that can be interpreted by Go's "path.Match" func.
+# https://pkg.go.dev/path#Match
 annotationKeys:
 # An example to propagate an annotation for MetalLB
 # https://metallb.universe.tf/usage/#requesting-specific-ips

--- a/controllers/namespace_controller.go
+++ b/controllers/namespace_controller.go
@@ -3,7 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 	"reflect"
 
 	"github.com/cybozu-go/accurate/pkg/constants"
@@ -100,7 +100,7 @@ func (r *NamespaceReconciler) propagateMeta(ctx context.Context, ns, parent *cor
 func (r *NamespaceReconciler) matchLabelKey(key string) bool {
 	for _, l := range r.LabelKeys {
 		// The glob pattern has been verified to be in the valid format when reading the config file.
-		if ok, _ := filepath.Match(l, key); ok {
+		if ok, _ := path.Match(l, key); ok {
 			return true
 		}
 	}
@@ -111,7 +111,7 @@ func (r *NamespaceReconciler) matchLabelKey(key string) bool {
 func (r *NamespaceReconciler) matchAnnotationKey(key string) bool {
 	for _, a := range r.AnnotationKeys {
 		// The glob pattern has been verified to be in the valid format when reading the config file.
-		if ok, _ := filepath.Match(a, key); ok {
+		if ok, _ := path.Match(a, key); ok {
 			return true
 		}
 	}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,14 +21,14 @@ type Config struct {
 func (c *Config) Validate(mapper meta.RESTMapper) error {
 	for _, key := range c.LabelKeys {
 		// Verify that pattern is a valid format.
-		if _, err := filepath.Match(key, ""); err != nil {
+		if _, err := path.Match(key, ""); err != nil {
 			return fmt.Errorf("malformed pattern for labelKeys %s: %w", key, err)
 		}
 	}
 
 	for _, key := range c.AnnotationKeys {
 		// Verify that pattern is a valid format.
-		if _, err := filepath.Match(key, ""); err != nil {
+		if _, err := path.Match(key, ""); err != nil {
 			return fmt.Errorf("malformed pattern for annotationKeys %s: %w", key, err)
 		}
 	}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,6 +19,20 @@ type Config struct {
 
 // Validate validates the configurations.
 func (c *Config) Validate(mapper meta.RESTMapper) error {
+	for _, key := range c.LabelKeys {
+		// Verify that pattern is a valid format.
+		if _, err := filepath.Match(key, ""); err != nil {
+			return fmt.Errorf("malformed pattern for labelKeys %s: %w", key, err)
+		}
+	}
+
+	for _, key := range c.AnnotationKeys {
+		// Verify that pattern is a valid format.
+		if _, err := filepath.Match(key, ""); err != nil {
+			return fmt.Errorf("malformed pattern for annotationKeys %s: %w", key, err)
+		}
+	}
+
 	for _, gvk := range c.Watches {
 		mapping, err := mapper.RESTMapping(schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind}, gvk.Version)
 		if err != nil {


### PR DESCRIPTION
ref: https://github.com/cybozu-go/accurate/issues/2
