### PR TITLE
Fix ct lint error

### DIFF
--- a/charts/accurate/Chart.yaml
+++ b/charts/accurate/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/accurate/templates/generated/generated.yaml
+++ b/charts/accurate/templates/generated/generated.yaml
@@ -235,8 +235,8 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ template "accurate.fullname"
-      . }}-serving-cert'
+    cert-manager.io/inject-ca-from: |
+      '{{ .Release.Namespace }}/{{ template "accurate.fullname" . }}-serving-cert'
   labels:
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "accurate.name" . }}'
@@ -270,8 +270,8 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ template "accurate.fullname"
-      . }}-serving-cert'
+    cert-manager.io/inject-ca-from: |
+      '{{ .Release.Namespace }}/{{ template "accurate.fullname" . }}-serving-cert'
   labels:
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "accurate.name" . }}'

--- a/config/kustomize-to-helm/overlays/templates/webhookcainjection_patch.yaml
+++ b/config/kustomize-to-helm/overlays/templates/webhookcainjection_patch.yaml
@@ -3,11 +3,13 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ template "accurate.fullname" . }}-serving-cert'
+    cert-manager.io/inject-ca-from: |
+      '{{ .Release.Namespace }}/{{ template "accurate.fullname" . }}-serving-cert'
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ template "accurate.fullname" . }}-serving-cert'
+    cert-manager.io/inject-ca-from: |
+      '{{ .Release.Namespace }}/{{ template "accurate.fullname" . }}-serving-cert'


### PR DESCRIPTION
#11 

Workaround for `ct lint --config ct.yaml` error.

steps to reproduce:

1. Change `version` value to `version: 0.1.1` in `Chart.yaml`

2. Run `ct lint`

```
$ docker run -it -v $(pwd):/app quay.io/helmpack/chart-testing
/ # cd app
/app # ct lint --config ct.yaml
Linting charts...

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 accurate => (version: "0.1.1", path: "charts/accurate")
------------------------------------------------------------------------------------------------------------------------

Linting chart 'accurate => (version: "0.1.1", path: "charts/accurate")'
Checking chart 'accurate => (version: "0.1.1", path: "charts/accurate")' for a version bump...
Old chart version: 0.1.0
New chart version: 0.1.1
Chart version ok.
Validating /app/charts/accurate/Chart.yaml...
Validation success! 👍
==> Linting charts/accurate
[INFO] Chart.yaml: icon is recommended
[ERROR] templates/: parse error at (accurate/templates/generated/generated.yaml:238): unexpected unclosed action in template clause

Error: 1 chart(s) linted, 1 chart(s) failed
------------------------------------------------------------------------------------------------------------------------
 ✖︎ accurate => (version: "0.1.1", path: "charts/accurate") > Error waiting for process: exit status 1
------------------------------------------------------------------------------------------------------------------------
Error: Error linting charts: Error processing charts
Error linting charts: Error processing charts
```