### PR TITLE
Support krew release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 /e2e
 /hack
 /.git
+/dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,13 +30,13 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ env.go-version }}
-    - run: make release-build
-    - name: Create Release
+    - name: GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        distribution: goreleaser
+        version: v0.180.3
+        args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        tagname="${GITHUB_REF#refs/tags/}"
-        if echo ${{ github.ref }} | grep -q -e '-'; then prerelease=-p; fi
-        gh release create -t "Release $tagname" $prerelease \
-          -n "See [CHANGELOG.md](./CHANGELOG.md) for details." \
-          "$tagname" build/*
+    - name: Update new version in krew-index
+      uses: rajatjindal/krew-release-bot@v0.0.40

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,4 +39,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Update new version in krew-index
-      uses: rajatjindal/krew-release-bot@v0.0.40
+      # v0.0.40 https://github.com/rajatjindal/krew-release-bot/releases/tag/v0.0.40
+      uses: rajatjindal/krew-release-bot@56925b62bacc2c652114d66a8256faaf0bf89fa9

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 # Binaries
 /bin
 /build
+/dist
 
 # Generated files
 /docs/book

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,40 @@
+builds:
+  - id: kubectl-accurate
+    main: ./cmd/kubectl-accurate
+    binary: kubectl-accurate
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+    ignore: # ref: https://goreleaser.com/deprecations/#builds-for-windowsarm64
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - builds:
+      - kubectl-accurate
+    name_template: "kubectl-{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    wrap_in_directory: false
+    format: tar.gz
+    files:
+      - LICENSE
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  skip: true
+
+release:
+  github:
+    owner: cybozu-go
+    name: accurate
+  prerelease: auto
+  name_template: "Release {{ .Tag }}"
+  footer: |
+    See [CHANGELOG.md](./CHANGELOG.md) for details.

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,67 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: accurate
+spec:
+  version: {{ .TagName }}
+  homepage: https://github.com/cybozu-go/accurate
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      {{addURIAndSha "https://github.com/cybozu-go/accurate/releases/download/{{ .TagName }}/kubectl-accurate_{{ .TagName }}_darwin_amd64.tar.gz" .TagName | indent 6 }}
+      bin: kubectl-accurate
+      files:
+        - from: kubectl-accurate
+          to: .
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      {{addURIAndSha "https://github.com/cybozu-go/accurate/releases/download/{{ .TagName }}/kubectl-accurate_{{ .TagName }}_darwin_arm64.tar.gz" .TagName | indent 6 }}
+      bin: kubectl-accurate
+      files:
+        - from: kubectl-accurate
+          to: .
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      {{addURIAndSha "https://github.com/cybozu-go/accurate/releases/download/{{ .TagName }}/kubectl-accurate_{{ .TagName }}_linux_amd64.tar.gz" .TagName | indent 6 }}
+      bin: kubectl-accurate
+      files:
+        - from: kubectl-accurate
+          to: .
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      {{addURIAndSha "https://github.com/cybozu-go/accurate/releases/download/{{ .TagName }}/kubectl-accurate_{{ .TagName }}_linux_arm64.tar.gz" .TagName | indent 6 }}
+      bin: kubectl-accurate
+      files:
+        - from: kubectl-accurate
+          to: .
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      {{addURIAndSha "https://github.com/cybozu-go/accurate/releases/download/{{ .TagName }}/kubectl-accurate_{{ .TagName }}_windows_amd64.tar.gz" .TagName | indent 6 }}
+      bin: kubectl-accurate.exe
+      files:
+        - from: kubectl-accurate.exe
+          to: .
+        - from: LICENSE
+          to: .
+  shortDescription: Manage Accurate features
+  description: |
+    kubectl-accurate is a subcommand of kubectl to manage Accurate features.
+    Read more documentation at: https://cybozu-go.github.io/accurate/kubectl-accurate.html

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -61,7 +61,9 @@ spec:
           to: .
         - from: LICENSE
           to: .
-  shortDescription: Manage Accurate features
+  shortDescription: Accurate is a Kubernetes controller for multi-tenancy.
   description: |
     kubectl-accurate is a subcommand of kubectl to manage Accurate features.
-    Read more documentation at: https://cybozu-go.github.io/accurate/kubectl-accurate.html
+    Accurate is a Kubernetes controller for multi-tenancy.
+    It propagates resources between namespaces accurately and allows tenant users to create/delete sub-namespaces.
+    Read more documentation at: https://cybozu-go.github.io/accurate/index.html

--- a/docs/install-plugin.md
+++ b/docs/install-plugin.md
@@ -4,6 +4,19 @@
 
 It is strongly recommended to install `kubectl-accurate` though Accurate can be used without the plugin.
 
+## Installing using Krew
+
+[Krew](https://krew.sigs.k8s.io/) is the plugin manager for kubectl command-line tool.
+
+See the [documentation](https://krew.sigs.k8s.io/docs/user-guide/setup/install/) for how to install Krew.
+
+```console
+$ kubectl krew update
+$ kubectl krew install accurate
+```
+
+## Installing manually
+
 1. Set `OS` to the operating system name
 
     OS is one of `linux`, `windows`, or `darwin` (MacOS).
@@ -14,7 +27,7 @@ It is strongly recommended to install `kubectl-accurate` though Accurate can be 
     $ OS=$(go env GOOS)
     ```
 
-1. Set `ARCH` to the operating system name
+2. Set `ARCH` to the operating system name
 
     ARCH is one of `amd64` or `arm64`.
 
@@ -24,17 +37,24 @@ It is strongly recommended to install `kubectl-accurate` though Accurate can be 
     $ ARCH=$(go env GOARCH)
     ```
 
-2. Download the binary and put it in a directory of your `PATH`.
+3. Set `VERSION` to the accurate version
+
+   See the accurate release page: https://github.com/cybozu-go/accurate/releases
+
+   ```console
+   $ VERSION=< The version you want to install >
+   ```
+
+4. Download the binary and put it in a directory of your `PATH`.
 
     The following is an example to install the plugin in `/usr/local/bin`.
 
     ```console
-    $ sudo curl -o /usr/local/bin/kubectl-accurate -sLf \
-      https://github.com/cybozu-go/accurate/releases/latest/download/kubectl-accurate-${OS}-${ARCH}
-    $ sudo chmod a+x /usr/local/bin/kubectl-accurate
+    $ curl -L -sS https://github.com/cybozu-go/accurate/releases/download/$(VERSION)/kubectl-accurate_$(VERSION)_$(OS)_$(ARCH).tar.gz \
+      | tar xz -C /usr/local/bin kubectl-accurate
     ```
 
-3. Check the installation
+5. Check the installation
 
     Run `kubectl accurate -h` and see the output looks like:
 

--- a/docs/install-plugin.md
+++ b/docs/install-plugin.md
@@ -39,7 +39,7 @@ $ kubectl krew install accurate
 
 3. Set `VERSION` to the accurate version
 
-   See the accurate release page: https://github.com/cybozu-go/accurate/releases
+   See the Accurate release page: https://github.com/cybozu-go/accurate/releases
 
    ```console
    $ VERSION=< The version you want to install >


### PR DESCRIPTION
refs: https://github.com/cybozu-go/accurate/issues/24

Release kubectl-accurate plugin to krew-index.

## Review Points

* Build the binary to be released using [goreleaser](https://github.com/goreleaser/goreleaser) and archive it as `.tar.gz`
  * krew plugins must be packaged as .zip or .tar.gz archives
  * https://krew.sigs.k8s.io/docs/developer-guide/plugin-manifest/#specifying-plugin-download-options
* Use krew-release-bot to update krew-index
  * https://krew.sigs.k8s.io/docs/developer-guide/release/automating-updates/

## Work to be done after merging

* Add tar.gz archive to v0.1.0 release
  * This will be done manually
  * `GORELEASER_CURRENT_TAG=v0.1.0 goreleaser release --skip-publish --skip-announce --skip-validate --rm-dist`
* Send a Pull Request to https://github.com/kubernetes-sigs/krew-index

## Testing

I've tested it in my own repository that I forked.

Release:
https://github.com/d-kuro/accurate/releases/tag/v0.1.1
https://github.com/d-kuro/accurate/runs/3809549806

Generate Krew manifests:

```console
$ docker run -v (pwd):/tmp/ rajatjindal/krew-release-bot:v0.0.40 krew-release-bot template --tag v0.1.1 --template-file /tmp/.krew.yaml
time="2021-10-06T00:40:29Z" level=info msg="getting sha256 for https://github.com/d-kuro/accurate/releases/download/v0.1.1/accurate_v0.1.1_darwin_amd64.tar.gz"
time="2021-10-06T00:40:30Z" level=info msg="downloaded file /tmp/768965160/1633480829"
time="2021-10-06T00:40:30Z" level=info msg="getting sha256 for https://github.com/d-kuro/accurate/releases/download/v0.1.1/accurate_v0.1.1_darwin_arm64.tar.gz"
time="2021-10-06T00:40:30Z" level=info msg="downloaded file /tmp/737136999/1633480830"
time="2021-10-06T00:40:30Z" level=info msg="getting sha256 for https://github.com/d-kuro/accurate/releases/download/v0.1.1/accurate_v0.1.1_linux_amd64.tar.gz"
time="2021-10-06T00:40:31Z" level=info msg="downloaded file /tmp/849511322/1633480830"
time="2021-10-06T00:40:31Z" level=info msg="getting sha256 for https://github.com/d-kuro/accurate/releases/download/v0.1.1/accurate_v0.1.1_linux_arm64.tar.gz"
time="2021-10-06T00:40:31Z" level=info msg="downloaded file /tmp/972828721/1633480831"
time="2021-10-06T00:40:31Z" level=info msg="getting sha256 for https://github.com/d-kuro/accurate/releases/download/v0.1.1/accurate_v0.1.1_windows_amd64.tar.gz"
time="2021-10-06T00:40:32Z" level=info msg="downloaded file /tmp/954888156/1633480831"
apiVersion: krew.googlecontainertools.github.com/v1alpha2
kind: Plugin
metadata:
  name: accurate
spec:
  version: v0.1.1
  homepage: https://github.com/cybozu-go/accurate
  platforms:
    - selector:
        matchLabels:
          os: darwin
          arch: amd64
      uri: https://github.com/d-kuro/accurate/releases/download/v0.1.1/accurate_v0.1.1_darwin_amd64.tar.gz
      sha256: 5cd5f58c63c9fcbdeaaec16be012c5b178f9788d1b1250d92f84df0c39dc80a9
      bin: kubectl-accurate
      files:
        - from: kubectl-accurate
          to: .
        - from: LICENSE
          to: .
    - selector:
        matchLabels:
          os: darwin
          arch: arm64
      uri: https://github.com/d-kuro/accurate/releases/download/v0.1.1/accurate_v0.1.1_darwin_arm64.tar.gz
      sha256: 2593fe9adaf50d404222b7a0ff2fb75c69421e379e1024d29ace1684061d59ae
      bin: kubectl-accurate
      files:
        - from: kubectl-accurate
          to: .
        - from: LICENSE
          to: .
    - selector:
        matchLabels:
          os: linux
          arch: amd64
      uri: https://github.com/d-kuro/accurate/releases/download/v0.1.1/accurate_v0.1.1_linux_amd64.tar.gz
      sha256: 6a76b327c6ea5bac270f7d386f8b6cb8a45090b042c15da9e309ee83f1bc8f30
      bin: kubectl-accurate
      files:
        - from: kubectl-accurate
          to: .
        - from: LICENSE
          to: .
    - selector:
        matchLabels:
          os: linux
          arch: arm64
      uri: https://github.com/d-kuro/accurate/releases/download/v0.1.1/accurate_v0.1.1_linux_arm64.tar.gz
      sha256: 31075c62d9d9074e37f1a012cfa35af533c3317b9698a506f5b24c15029877c4
      bin: kubectl-accurate
      files:
        - from: kubectl-accurate
          to: .
        - from: LICENSE
          to: .
    - selector:
        matchLabels:
          os: windows
          arch: amd64
      uri: https://github.com/d-kuro/accurate/releases/download/v0.1.1/accurate_v0.1.1_windows_amd64.tar.gz
      sha256: 52a62a4851f6e030f59518458d043e0fc40bcd9e45b1e1233ad51888bcf7a540
      bin: kubectl-accurate.exe
      files:
        - from: kubectl-accurate.exe
          to: .
        - from: LICENSE
          to: .
  shortDescription: Manage Accurate features
  description: |
    kubectl-accurate is a subcommand of kubectl to manage Accurate features.
    Read more documentation at: https://cybozu-go.github.io/accurate/kubectl-accurate.html
```

Install krew manifests:

```console
$ kubectl krew install --manifest=plugin.yaml
Installing plugin: accurate
Installed plugin: accurate
\
 | Use this plugin:
 | 	kubectl accurate
 | Documentation:
 | 	https://github.com/cybozu-go/accurate
/
```