### PR TITLE
Fixed release procedure for Helm chart

### DIFF
--- a/.cr.yaml
+++ b/.cr.yaml
@@ -1,4 +1,0 @@
-# This file is the config file for helm/chart-releaser
-owner: cybozu-go
-git-repo: accurate
-release-name-template: "{{ .Name }}-chart-v{{ .Version }}"

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -2,14 +2,11 @@ name: Release Charts
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - 'charts/**'
-      - '!**.md'
+    tags:
+      - 'chart-v*'
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -17,14 +14,69 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
         with:
-          config: .cr.yaml
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          version: v3.6.3
+
+      - name: Check chart version
+        run: |
+          tag_version=${GITHUB_REF##*/chart-v}
+          chart_version=$(cat charts/accurate/Chart.yaml | grep 'version:' | sed 's/version:\s//')
+
+          if [ "$tag_version" != "$chart_version" ]; then
+            echo "Different versions: tag \"$tag_version\", chart \"$chart_version\""
+            exit 1
+          fi
+
+      - name: Packaging the chart
+        run: helm package ./charts/accurate/
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: helm-charts
+          path: ./accurate-*.tgz
+          retention-days: 1
+
+  publish:
+    name: Publish charts on GitHub Pages
+    runs-on: ubuntu-20.04
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.6.3
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: helm-charts
+
+      - name: Update charts index
+        run: helm repo index --url https://cybozu-go.github.io/accurate/ --merge index.yaml .
+
+      - run: git add .
+
+      - name: Check diffs
+        run: |
+          diffs=$(git status -s)
+          if [ "$diffs" = "" ]; then
+            echo "NO_DIFF=1" >> $GITHUB_ENV
+          else
+            printf "%s\n" "$diffs"
+          fi
+
+      - name: Commit changes
+        if: env.NO_DIFF != '1'
+        run: |
+          git config --global user.name 'Cybozu Neco'
+          git config --global user.email 'cybozu-neco@users.noreply.github.com'
+          git commit -m 'update'
+
+      - name: Push to gh-pages
+        if: env.NO_DIFF != '1'
+        run: git push origin gh-pages

--- a/.github/workflows/mdbook.yaml
+++ b/.github/workflows/mdbook.yaml
@@ -24,8 +24,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         ref: gh-pages
-    # ignore helm chart index file
-    - run: ls | grep -v 'index.yaml' | xargs rm -rf
+    # ignore helm chart index file and chart archive file.
+    - run: ls | grep -v -E 'index.yaml|accurate-.*\.tgz' | xargs rm -rf
     - uses: actions/download-artifact@v2
       with:
         name: book

--- a/charts/accurate/README.md
+++ b/charts/accurate/README.md
@@ -74,6 +74,7 @@ Accurate Helm Chart will be released independently.
 This will prevent the Accurate version from going up just by modifying the Helm Chart.
 
 You must change the version of `Chart.yaml` when making changes to the Helm Chart.
-CI fails with lint error when creating a Pull Request without changing the version of `Chart.yaml`.
 
-When a pull request with Chart changes is merged into the main branch, [helm/chart-releaser-action](https://github.com/helm/chart-releaser-action) will automatically create a GitHub release.
+Pushing a tag like `chart-v<chart version>` will cause GitHub Actions to release chart.
+Chart versions are expected to follow [Semantic Versioning](https://semver.org/).
+If the chart version in the tag does not match the version listed in `Chart.yaml`, the release will fail.

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,4 +1,4 @@
 # This file is the config file for helm/chart-testing
 target-branch: main
 validate-maintainers: false
-check-version-increment: true
+check-version-increment: false


### PR DESCRIPTION
Fixed release procedure for Helm chart.

* Helm Chart releases will no longer create GitHub releases
* Chart archive files will be pushed directly to the `gh-pages` branch
* Chart release is done by manually pushing the tag
  * Chart version increment check that used to be performed in pull requests is no longer performed

I checked the workflow in the forked repository:

https://github.com/d-kuro/accurate/actions/runs/1358984538
https://github.com/d-kuro/accurate/commit/78e4fc592e87efc96e4bbb941d7e60c475664108
https://d-kuro.github.io/accurate/accurate-0.1.3.tgz