### PR TITLE
Import auth plugin in kubectl-accurate

### DIFF
--- a/cmd/kubectl-accurate/sub/cmd.go
+++ b/cmd/kubectl-accurate/sub/cmd.go
@@ -3,6 +3,9 @@ package sub
 import (
 	"os"
 
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
 	"github.com/cybozu-go/accurate"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"


### PR DESCRIPTION
`kubectl-accurate` cannot work with GKE.
It seems to need import auth plugins in kubectl-accurate.

```
$ ./bin/kubectl-accurate list
Error: no Auth Provider found for name "gcp"
```

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>