### PR TITLE
Fix infinite reconciliation on non-existent namespaces

### DIFF
--- a/controllers/propagate.go
+++ b/controllers/propagate.go
@@ -162,6 +162,9 @@ func (r *PropagateController) handleDelete(ctx context.Context, req ctrl.Request
 
 	ns := &corev1.Namespace{}
 	if err := r.Get(ctx, client.ObjectKey{Name: req.Namespace}, ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
 		return fmt.Errorf("failed to get namespace %s: %w", req.Namespace, err)
 	}
 


### PR DESCRIPTION
There is a bug in the accurate controller that would try to delete resources in non-existent namespaces forever.