### PR TITLE
Do not delete non-propagated resources in template/root namespaces

### DIFF
--- a/controllers/namespace_controller.go
+++ b/controllers/namespace_controller.go
@@ -59,6 +59,9 @@ func (r *NamespaceReconciler) reconcile(ctx context.Context, ns *corev1.Namespac
 		}
 		// a template instance may also be a root or a template namespace, so don't return here.
 	} else {
+		// Here, ns is neither a sub-namespace nor a template instance.
+		// Since there is no parent|template namespace for this namespace,
+		// propagated resources in this namespace, if any, should be deleted.
 		if err := r.deletePropagatedResources(ctx, ns); err != nil {
 			return err
 		}
@@ -244,6 +247,13 @@ func (r *NamespaceReconciler) deleteResource(ctx context.Context, res *unstructu
 	}
 	for i := range l.Items {
 		obj := &l.Items[i]
+
+		from := obj.GetAnnotations()[constants.AnnFrom]
+		if from == "" {
+			// don't delete origins
+			continue
+		}
+
 		if err := r.Delete(ctx, obj); err != nil {
 			return fmt.Errorf("failed to delete %s/%s of %s: %w", ns, obj.GetName(), gvkStr, err)
 		}

--- a/docs/reconcile.md
+++ b/docs/reconcile.md
@@ -21,7 +21,7 @@ These namespaces reference a template namespace and propagate the labels, annota
     - the value of `accurate.cybozu.com/from` annotation is not the template namespace name, or
     - there is not a resource of the same kind and the same name in the template namespace.
 
-### Namespaces w/o `accurate.cybozu.com/from` and `accurate.cybozu.com/template` labels
+### Namespaces w/o `accurate.cybozu.com/type` and `accurate.cybozu.com/template` labels
 
 If these labels are removed from the Namespace, Accurate should delete propagated resources with mode == `update`.
 


### PR DESCRIPTION
There is a bug that would delete non-propagated resources in
namespaces that are neither a sub-namespace nor a template instance
when resources are annotated with `accurate.cybozu.com/propagate=update`.