### PR TITLE
Adjust QPS for querying kube-apiserver to 50

### DIFF
--- a/cmd/accurate-controller/sub/root.go
+++ b/cmd/accurate-controller/sub/root.go
@@ -14,7 +14,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-const defaultConfigPath = "/etc/accurate/config.yaml"
+const (
+	defaultConfigPath = "/etc/accurate/config.yaml"
+	defaultQPS        = 50
+)
 
 var options struct {
 	configFile       string
@@ -23,6 +26,7 @@ var options struct {
 	leaderElectionID string
 	webhookAddr      string
 	certDir          string
+	qps              int
 	zapOpts          zap.Options
 }
 
@@ -67,6 +71,7 @@ func init() {
 	fs.StringVar(&options.leaderElectionID, "leader-election-id", "accurate", "ID for leader election by controller-runtime")
 	fs.StringVar(&options.webhookAddr, "webhook-addr", ":9443", "Listen address for the webhook endpoint")
 	fs.StringVar(&options.certDir, "cert-dir", "", "webhook certificate directory")
+	fs.IntVar(&options.qps, "apiserver-qps-throttle", defaultQPS, "The maximum QPS to the API server.")
 
 	goflags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(goflags)

--- a/cmd/accurate-controller/sub/run.go
+++ b/cmd/accurate-controller/sub/run.go
@@ -45,7 +45,14 @@ func subMain(ns, addr string, port int) error {
 		return fmt.Errorf("unable to load the configuration file: %w", err)
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	restCfg, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get REST config: %w", err)
+	}
+	restCfg.QPS = float32(options.qps)
+	restCfg.Burst = int(restCfg.QPS * 1.5)
+
+	mgr, err := ctrl.NewManager(restCfg, ctrl.Options{
 		Scheme:                  scheme,
 		NewClient:               cluster.NewCachingClient,
 		MetricsBindAddress:      options.metricsAddr,

--- a/docs/accurate-controller.md
+++ b/docs/accurate-controller.md
@@ -49,6 +49,7 @@ watches:
 Flags:
       --add_dir_header                   If true, adds the file directory to the header
       --alsologtostderr                  log to standard error as well as files
+      --apiserver-qps-throttle int       The maximum QPS to the API server. (default 50)
       --cert-dir string                  webhook certificate directory
       --config-file string               Configuration file path (default "/etc/accurate/config.yaml")
       --health-probe-addr string         Listen address for health probes (default ":8081")


### PR DESCRIPTION
to match the limit of HNC.
https://github.com/kubernetes-sigs/multi-tenancy/issues/369