### PR TITLE
Fix the broken chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 # Tool versions
 CTRL_TOOLS_VERSION=0.7.0
 CTRL_RUNTIME_VERSION := $(shell awk '/sigs.k8s.io\/controller-runtime/ {print substr($$2, 2)}' go.mod)
-KUSTOMIZE_VERSION = 4.4.1
+# Do NOT update kustomize to 4.0.5 or higher until the following issue is resolved.
+# https://github.com/kubernetes-sigs/kustomize/issues/3969
+KUSTOMIZE_VERSION = 4.0.4
 HELM_VERSION = 3.7.1
 CRD_TO_MARKDOWN_VERSION = 0.0.3
 MDBOOK_VERSION = 0.4.14

--- a/charts/accurate/crds/accurate.cybozu.com_subnamespaces.yaml
+++ b/charts/accurate/crds/accurate.cybozu.com_subnamespaces.yaml
@@ -21,14 +21,10 @@ spec:
         description: SubNamespace is the Schema for the subnamespaces API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.'
             type: string
           metadata:
             type: object
@@ -38,8 +34,7 @@ spec:
               annotations:
                 additionalProperties:
                   type: string
-                description: Annotations are the annotations to be propagated to the
-                  sub-namespace.
+                description: Annotations are the annotations to be propagated to the sub-namespace.
                 type: object
               labels:
                 additionalProperties:

--- a/charts/accurate/templates/generated/generated.yaml
+++ b/charts/accurate/templates/generated/generated.yaml
@@ -243,8 +243,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ template "accurate.fullname"
-      . }}-serving-cert'
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ template "accurate.fullname" . }}-serving-cert'
   labels:
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "accurate.name" . }}'
@@ -277,8 +276,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ template "accurate.fullname"
-      . }}-serving-cert'
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ template "accurate.fullname" . }}-serving-cert'
   labels:
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "accurate.name" . }}'

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,7 +1,7 @@
 KIND_VERSION = 0.11.1
 KUBERNETES_VERSION = 1.22.4
 CERT_MANAGER_VERSION = 1.6.1
-SEALED_SECRETS_VERSION = 0.16.0
+SEALED_SECRETS_VERSION = 0.17.2
 
 KIND := $(dir $(shell pwd))/bin/kind
 KUBECTL := $(dir $(shell pwd))/bin/kubectl
@@ -71,8 +71,7 @@ $(HELM):
 
 $(KUBESEAL):
 	mkdir -p ../bin
-	curl -sfL -o $@ https://github.com/bitnami-labs/sealed-secrets/releases/download/v$(SEALED_SECRETS_VERSION)/kubeseal-linux-amd64
-	chmod a+x $@
+	curl -sfL https://github.com/bitnami-labs/sealed-secrets/releases/download/v$(SEALED_SECRETS_VERSION)/kubeseal-$(SEALED_SECRETS_VERSION)-linux-amd64.tar.gz | tar -C ../bin -xzf -
 
 $(KUBECTL_ACCURATE): $(wildcard ../cmd/kubectl-accurate/*/*.go)
 	mkdir -p ../bin


### PR DESCRIPTION
kustomize 4.0.5 or later has a issue with long lines being broken.
https://github.com/kubernetes-sigs/kustomize/issues/3969

This will cause `helm install` to fail.

Signed-off-by: zoetrope <a.ikezoe@gmail.com>