### PR TITLE
docs: clarify the behavior of label/annotation propagation

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -12,7 +12,7 @@ Any Namespace other than sub-namespaces can reference a template Namespace with 
 
 Sub-namespace can reference a root or another sub-namespace as its parent.
 
-Accurate propagates the Namespace labels, annotations, and namespace-scope resources from a referenced Namespace to referencing Namespaces.
+When configured to do so, Accurate propagates the Namespace labels, annotations, and namespace-scope resources from a referenced Namespace to referencing Namespaces.
 
 Circular references are prohibited by an admission webhook.
 

--- a/docs/subnamespaces.md
+++ b/docs/subnamespaces.md
@@ -30,6 +30,8 @@ metadata:
     team: foo
 ```
 
+Accurate only propagates labels/annotations that have been configured in that respect via the `labelKeys` and `annotationKeys` parameters in `config.yaml`. This prevents the propagation of labels/annotations that were not meant to do so.
+
 ### Preparing resources for tenant users
 
 In almost all cases, a root Namespace should have RoleBinding for a group of tenant users.


### PR DESCRIPTION
The manual states that Accurate propagates labels/annotations, however (although it makes sense) it is not plainly obvious that Accurate only propagates labels/annotations that have been configured in that matter via config.yaml.

This PR adds some minor clarifications in the manual to prevent such misunderstandings