### PR TITLE
fix: add missing spec.issuerRef.group to cert-manager Certificate|

### DIFF
--- a/charts/accurate/templates/certificate.yaml
+++ b/charts/accurate/templates/certificate.yaml
@@ -10,6 +10,7 @@ spec:
     - {{ template "accurate.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc
     - {{ template "accurate.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
+    group: cert-manager.io
     kind: Issuer
     name: {{ template "accurate.fullname" . }}-selfsigned-issuer
   secretName: webhook-server-cert

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -20,6 +20,7 @@ spec:
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
   issuerRef:
+    group: cert-manager.io
     kind: Issuer
     name: selfsigned-issuer
   secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize


### PR DESCRIPTION
We are using cert-manager/approver-policy in our clusters, and are hitting this issue: https://github.com/cert-manager/approver-policy/issues/179

This PR adds the `cert-manager.io` as the issuer group - which is anyway the default in cert-manager controller.