### PR TITLE
build(deps): finalize bump to Kubernetes 1.28

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,9 +36,9 @@ jobs:
     strategy:
       matrix:
         k8s-version:
-        - v1.25.11 # renovate: kindest/node
         - v1.26.6 # renovate: kindest/node
         - v1.27.3 # renovate: kindest/node
+        - v1.28.0 # renovate: kindest/node
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -4,7 +4,7 @@ registries:
   - type: standard
     ref: v4.23.0 # renovate: depName=aquaproj/aqua-registry
 packages:
-  - name: kubernetes/kubectl@v1.27.3
+  - name: kubernetes/kubectl@v1.28.2
   - name: kubernetes-sigs/kubebuilder@v3.11.0
   - name: kubernetes-sigs/kustomize@kustomize/v5.1.0
   - name: kubernetes-sigs/kind@v0.20.0

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,4 +1,4 @@
-KUBERNETES_VERSION = v1.27.3 # renovate: kindest/node
+KUBERNETES_VERSION = v1.28.0 # renovate: kindest/node
 
 KUBECTL_ACCURATE := $(dir $(shell pwd))/bin/kubectl-accurate
 KUBECONFIG := $(shell pwd)/.kubeconfig


### PR DESCRIPTION
When reading through the project docs, I noticed https://cybozu-go.github.io/accurate/maintenance.html#how-to-update-supported-kubernetes. I already did the last step in https://github.com/cybozu-go/accurate/pull/88, so this PR is to finalize the upgrade to K8s 1.28 as documented.