### PR TITLE
feat: add DisablePropagateGenerated feature gate

### DIFF
--- a/cmd/accurate-controller/sub/root.go
+++ b/cmd/accurate-controller/sub/root.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/cybozu-go/accurate"
+	"github.com/cybozu-go/accurate/pkg/config"
 	"github.com/spf13/cobra"
 	klog "k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -72,6 +73,8 @@ func init() {
 	fs.StringVar(&options.webhookAddr, "webhook-addr", ":9443", "Listen address for the webhook endpoint")
 	fs.StringVar(&options.certDir, "cert-dir", "", "webhook certificate directory")
 	fs.IntVar(&options.qps, "apiserver-qps-throttle", defaultQPS, "The maximum QPS to the API server.")
+
+	config.DefaultMutableFeatureGate.AddFlag(fs)
 
 	goflags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(goflags)

--- a/controllers/propagate.go
+++ b/controllers/propagate.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cybozu-go/accurate/pkg/config"
 	"github.com/cybozu-go/accurate/pkg/constants"
+	"github.com/cybozu-go/accurate/pkg/feature"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -132,7 +134,7 @@ func (r *PropagateController) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, err
 		}
 	case "":
-		if ann[constants.AnnGenerated] != notGenerated {
+		if !config.DefaultFeatureGate.Enabled(feature.DisablePropagateGenerated) && ann[constants.AnnGenerated] != notGenerated {
 			if err := r.checkController(ctx, obj); err != nil {
 				logger.Error(err, "failed to check the controller reference")
 				return ctrl.Result{}, err
@@ -361,7 +363,7 @@ func (r *PropagateController) SetupWithManager(mgr ctrl.Manager) error {
 		if _, ok := ann[constants.AnnPropagate]; ok {
 			return true
 		}
-		if ann[constants.AnnGenerated] == notGenerated {
+		if config.DefaultFeatureGate.Enabled(feature.DisablePropagateGenerated) || ann[constants.AnnGenerated] == notGenerated {
 			return false
 		}
 		if metav1.GetControllerOfNoCopy(obj) != nil {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/apimachinery v0.28.2
 	k8s.io/cli-runtime v0.28.2
 	k8s.io/client-go v0.28.2
+	k8s.io/component-base v0.28.2
 	k8s.io/klog/v2 v2.100.1
 	sigs.k8s.io/controller-runtime v0.16.2
 	sigs.k8s.io/yaml v1.3.0
@@ -20,6 +21,7 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
@@ -79,7 +81,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.28.2 // indirect
-	k8s.io/component-base v0.28.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20230918164632-68afd615200d // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZx
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/pkg/config/feature_gate.go
+++ b/pkg/config/feature_gate.go
@@ -1,0 +1,13 @@
+package config
+
+import "k8s.io/component-base/featuregate"
+
+var (
+	// DefaultMutableFeatureGate is a mutable version of DefaultFeatureGate.
+	// Only top-level commands/options setup should make use of this.
+	DefaultMutableFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+
+	// DefaultFeatureGate is a shared global FeatureGate.
+	// Top-level commands/options setup that needs to modify this feature gate should use DefaultMutableFeatureGate.
+	DefaultFeatureGate featuregate.FeatureGate = DefaultMutableFeatureGate
+)

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -1,0 +1,20 @@
+package feature
+
+import (
+	"github.com/cybozu-go/accurate/pkg/config"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/featuregate"
+)
+
+// DisablePropagateGenerated will disable watch for owners with propagate-generated
+// annotation. This could be useful to avoid Accurate from attempting to modify resources
+// in namespaces that should be out-of-scope for Accurate.
+const DisablePropagateGenerated featuregate.Feature = "DisablePropagateGenerated"
+
+func init() {
+	runtime.Must(config.DefaultMutableFeatureGate.Add(defaultFeatureGates))
+}
+
+var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	DisablePropagateGenerated: {Default: false, PreRelease: featuregate.Alpha},
+}


### PR DESCRIPTION
This adds a temporary/experimental feature gate that allows a user to disable the [Annotating a resource to propagate resources created from it](https://cybozu-go.github.io/accurate/propagation.html#annotating-a-resource-to-propagate-resources-created-from-it) feature. As the Accurate controller works at present, we need a way to prevent Accurate from touching resources in namespaces that are not and never will be, managed by Accurate.

The idea is to deprecate and eventually remove this new feature gate when the root cause is fixed.

Relates to https://github.com/cybozu-go/accurate/issues/87 (workaround)


````
$ bin/accurate-controller --help
accurate controller

Usage:
  accurate-controller [flags]

Flags:
      --add_dir_header                    If true, adds the file directory to the header of the log messages
      --alsologtostderr                   log to standard error as well as files (no effect when -logtostderr=true)
      --apiserver-qps-throttle int        The maximum QPS to the API server. (default 50)
      --cert-dir string                   webhook certificate directory
      --config-file string                Configuration file path (default "/etc/accurate/config.yaml")
      --feature-gates mapStringBool       A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
                                          AllAlpha=true|false (ALPHA - default=false)
                                          AllBeta=true|false (BETA - default=false)
                                          DisablePropagateGenerated=true|false (ALPHA - default=false)

````