### PR TITLE
docs: deprecate propagate-generated feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It propagates resources between namespaces and allows tenant users to create/del
 
 - Resource propagation between namespaces
     - Any namespace-scoped resource can be propagated.
-    - Generated resources can be automatically checked and propagated.
+    - ⚠️ Generated resources can be automatically checked and propagated. (DEPRECATED)
 - Inheriting labels and annotations from parent namespaces
 - Template namespaces
 - SubNamespace custom resource for tenant users

--- a/controllers/propagate.go
+++ b/controllers/propagate.go
@@ -21,6 +21,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+// Deprecated: Part of the deprecated propagate-generated feature subject for
+// removal soon.
 const notGenerated = "false"
 
 func cloneResource(res *unstructured.Unstructured, ns string) *unstructured.Unstructured {
@@ -134,6 +136,7 @@ func (r *PropagateController) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, err
 		}
 	case "":
+		//lint:ignore SA1019 subject for removal
 		if !config.DefaultFeatureGate.Enabled(feature.DisablePropagateGenerated) && ann[constants.AnnGenerated] != notGenerated {
 			if err := r.checkController(ctx, obj); err != nil {
 				logger.Error(err, "failed to check the controller reference")
@@ -315,6 +318,8 @@ func (r *PropagateController) propagateUpdate(ctx context.Context, obj, parent *
 	return nil
 }
 
+// Deprecated: Part of the deprecated propagate-generated feature subject for
+// removal soon.
 func (r *PropagateController) checkController(ctx context.Context, obj *unstructured.Unstructured) error {
 	cref := metav1.GetControllerOfNoCopy(obj)
 	if cref == nil {
@@ -363,6 +368,7 @@ func (r *PropagateController) SetupWithManager(mgr ctrl.Manager) error {
 		if _, ok := ann[constants.AnnPropagate]; ok {
 			return true
 		}
+		//lint:ignore SA1019 subject for removal
 		if config.DefaultFeatureGate.Enabled(feature.DisablePropagateGenerated) || ann[constants.AnnGenerated] == notGenerated {
 			return false
 		}

--- a/controllers/propagate_test.go
+++ b/controllers/propagate_test.go
@@ -392,6 +392,7 @@ var _ = Describe("SubNamespace controller", func() {
 			}
 			return svc1.Annotations[constants.AnnPropagate]
 		}).Should(Equal(constants.PropagateUpdate))
+		//lint:ignore SA1019 subject for removal
 		Expect(svc1.Annotations).NotTo(HaveKey(constants.AnnGenerated))
 
 		svc2 := &corev1.Service{}
@@ -408,6 +409,7 @@ var _ = Describe("SubNamespace controller", func() {
 			if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: rootNS, Name: "svc2"}, svc2); err != nil {
 				return ""
 			}
+			//lint:ignore SA1019 subject for removal
 			return svc2.Annotations[constants.AnnGenerated]
 		}).Should(Equal(notGenerated))
 	})

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -6,5 +6,5 @@ The table below is a list of annotations used by Accurate.
 | ----------------------------------------- | ------------------------ | ------------------------------ | ------------------------------------------------------------------ |
 | `accurate.cybozu.com/from`                | Namespace name           | Copied or propagated resources | The namespace name from which the source resource was copied.      |
 | `accurate.cybozu.com/propagate`           | `"create"` or `"update"` | Namespace-scoped resources     | Specify propagation mode.                                          |
-| `accurate.cybozu.com/propagate-generated` | `"create"` or `"update"` | Namespace-scoped resources     | Specify propagation mode of generated resources.                   |
-| `accurate.cybozu.com/generated`           | `false`                  | Namespace-scoped resources     | The result of checking if this is generated from another resource. |
+| `accurate.cybozu.com/propagate-generated` ⚠️ | `"create"` or `"update"` | Namespace-scoped resources     | `DEPRECATED` Specify propagation mode of generated resources.                   |
+| `accurate.cybozu.com/generated` ⚠️          | `false`                  | Namespace-scoped resources     | `DEPRECATED` The result of checking if this is generated from another resource. |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -25,7 +25,11 @@ Mode is one of the following:
 - `create`: the resource will be created in referencing Namespaces if missing.
 - `update`: the resource will be created in referencing Namespaces if missing, or will be updated if not identical, or will be deleted when the resource in the referenced Namespace is deleted.
 
-## Propagating generated resources
+## Propagating generated resources (DEPRECATED)
+
+> [!WARNING]  
+> Propagating generated resources is a deprecated feature and is subject for
+> removal soon.
 
 If a resource annotated with `accurate.cybozu.com/propagate-generated=<mode>` creates a resource and set an owner reference in the created resource, Accurate automatically adds `accurate.cybozu.com/propagate=<mode>` to the created resource.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -36,7 +36,7 @@ Since these are fundamentally different requirements, we decided to develop our 
 - Support the following propagation modes:
     - `create`: if the resource does not exist, copy the resource from the parent namespace.
     - `update`: if the resource is missing or different from the parent namespace, create or update it.  If the parent resource is deleted, the copy will also be deleted.
-- Propagate generated resources
+- ⚠️ Propagate generated resources (DEPRECATED)
     - Resources created and controlled by another resource can be automatically propagated.
     - The generator resource should be annotated with `accurate.cybozu.com/propagate-generated: <mode>`.
 - Propagate labels and annotations of parent or template namespaces

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -51,7 +51,6 @@ Without propagating Role/RoleBinding, the tenant user would be able to do nothin
 - Resource propagation between namespaces
 
     Accurate can propagate any namespace-scope resource including custom resources between Namespaces.
-    Moreover, Accurate can detect generated resources owned by another resource and propagate them.
 
 - Inheriting labels and annotations creation/update from parent namespaces
 

--- a/docs/propagation.md
+++ b/docs/propagation.md
@@ -29,7 +29,15 @@ metadata:
     accurate.cybozu.com/propagate: <mode>
 ```
 
-## Annotating a resource to propagate resources created from it
+## Annotating a resource to propagate resources created from it (DEPRECATED)
+
+> [!WARNING]  
+> Propagating generated resources is a deprecated feature and is subject for
+> removal soon. Commonly used tools like cert-manager and sealed-secrets now
+> provide features for adding annotations/labels to resources created from
+> user-facing custom resources. These features can be used for migration to
+> ensure the standard `accurate.cybozu.com/propagate` annotation is added to
+> generated resources.
 
 For example, a Secret created from cert-manager's Certificate can automatically be propagated.
 

--- a/docs/reconcile.md
+++ b/docs/reconcile.md
@@ -73,7 +73,7 @@ These resources can be propagated to other namespaces.
 - If the resource exists and the annotation value is `update`, Accurate creates or updates a copy in all sub-namespaces if missing or different.
 - When a resource is deleted, Accurate checks sub-namespaces and delete the resource of the same kind and the same name if the resource is annotated with `accurate.cybozu.com/propagate=update`.
 
-### Resources owned by another resource that is annotated with `accurate.cybozu.com/propagate-generated`
+### Resources owned by another resource that is annotated with `accurate.cybozu.com/propagate-generated` (DEPRECATED)
 
 Accurate annotates the resource with `accurate.cybozu.com/propagate`.
 The annotation value is the same as `accurate.cybozu.com/propagate-generated` annotation.

--- a/pkg/constants/meta.go
+++ b/pkg/constants/meta.go
@@ -19,7 +19,9 @@ const (
 	AnnFrom               = MetaPrefix + "from"
 	AnnPropagate          = MetaPrefix + "propagate"
 	AnnPropagateGenerated = MetaPrefix + "propagate-generated"
-	AnnGenerated          = MetaPrefix + "generated"
+	// Deprecated: Part of the deprecated propagate-generated feature subject for
+	// removal soon.
+	AnnGenerated = MetaPrefix + "generated"
 )
 
 // Label or annotation values


### PR DESCRIPTION
As agreed in https://github.com/cybozu-go/accurate/issues/87#issuecomment-1760038161 we think it's time to initiate the removal of the propagate-generated feature. This PR does:
- update docs to inform about the deprecated feature
-  mark affected code as deprecated

Relates to https://github.com/cybozu-go/accurate/issues/87
Close https://github.com/cybozu-go/accurate/issues/93