### PR TITLE
chore: mark generated files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+charts/accurate/crds/* linguist-generated=true
+charts/accurate/templates/generated/* linguist-generated=true
+config/crd/bases/* linguist-generated=true
+config/rbac/role.yaml linguist-generated=true
+config/webhook/manifests.yaml linguist-generated=true
+docs/crd_*.md linguist-generated=true
+
+**/zz_generated.*.go linguist-generated=true


### PR DESCRIPTION
This PR is a simple improvement to the review process by using the feature described here: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

With this merged it will be a lot simpler to review PRs affecting generated files, as the marked as generated files will be collapsed by default in the PR diff-view. Example: https://github.com/cybozu-go/accurate/pull/96 will be easier to review and comment on.