### PR TITLE
chore: enable DisablePropagateGenerated feature gate by default

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -19,7 +19,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	accuratev1 "github.com/cybozu-go/accurate/api/v1"
+	"github.com/cybozu-go/accurate/pkg/config"
 	"github.com/cybozu-go/accurate/pkg/constants"
+	"github.com/cybozu-go/accurate/pkg/feature"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -48,6 +50,9 @@ var _ = BeforeSuite(func() {
 		zap.StacktraceLevel(zapcore.DPanicLevel),
 		zap.Level(zapcore.Level(-5)),
 	))
+
+	// Some tests are still testing the propagate-generated feature
+	Expect(config.DefaultMutableFeatureGate.SetFromMap(map[string]bool{string(feature.DisablePropagateGenerated): false})).To(Succeed())
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{

--- a/docs/config.md
+++ b/docs/config.md
@@ -168,4 +168,35 @@ controller:
 <snip>
 ```
 
+## Feature Gates
+
+Feature gates are a set of key=value pairs that describe operator features.
+You can turn these features on or off using the `--feature-gates` command line flag.
+Use `-h` flag to see a full set of feature gates.
+
+To set feature gates, use the `--feature-gates` flag assigned to a list of feature pairs:
+
+```shell
+--feature-gates=...,DisablePropagateGenerated=false
+```
+
+The following table is a summary of the feature gates that you can set.
+
+- The "Since" column contains the Accurate release when a feature is introduced
+  or its release stage is changed.
+- The "Until" column, if not empty, contains the last Accurate release in which
+  you can still use a feature gate.
+
+{{< table caption="Feature gates for features in Alpha or Beta states" sortable="true" >}}
+
+| Feature | Default | Stage | Since | Until |
+|---------|---------|-------|-------|-------|
+| `DisablePropagateGenerated` | `false` | Alpha | 1.2.0 | 1.3.0 |
+| `DisablePropagateGenerated` | `true` | Beta | 1.3.0 | |
+
+Each feature gate is designed for enabling/disabling a specific feature:
+
+- `DisablePropagateGenerated`: Disable [propagating generated resources](concepts.md#propagating-generated-resources),
+  which is a feature subject for removal soon.
+
 [ResourceQuota]: https://kubernetes.io/docs/concepts/policy/resource-quotas/

--- a/e2e/values.yaml
+++ b/e2e/values.yaml
@@ -6,7 +6,8 @@ image:
 controller:
   extraArgs:
     - --zap-log-level=5
-
+    # Some tests are still testing the propagate-generated feature
+    - --feature-gates=DisablePropagateGenerated=false
   config:
     labelKeys:
       - team

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -16,5 +16,5 @@ func init() {
 }
 
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	DisablePropagateGenerated: {Default: false, PreRelease: featuregate.Alpha},
+	DisablePropagateGenerated: {Default: true, PreRelease: featuregate.Beta},
 }


### PR DESCRIPTION
As agreed in https://github.com/cybozu-go/accurate/issues/87#issuecomment-1760038161, this graduates the `DisablePropagateGenerated ``to Beta and enables it by default. This does not fix https://github.com/cybozu-go/accurate/issues/87, but I still think we can close the issue as "not a problem" - since the problematic feature is no longer enabled by default.

Should probably be merged/released after https://github.com/cybozu-go/accurate/pull/95. This PR is quite easy to rebase, so it can just stay open until we are ready for these changes.

Close https://github.com/cybozu-go/accurate/issues/87

PS: The structure/wording of the new feature gates doc paragraph is almost a copy of https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/. Kudos to Kubernetes documentation contributors/maintainers. 🙏 