### PR TITLE
fix(helm): controller.extraArgs should be treated as list

### DIFF
--- a/charts/accurate/templates/deployment.yaml
+++ b/charts/accurate/templates/deployment.yaml
@@ -27,7 +27,8 @@ spec:
           imagePullPolicy: {{ . }}
           {{- end }}
           {{- with .Values.controller.extraArgs }}
-          args: {{ . }}
+          args:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
             - containerPort: 9443


### PR DESCRIPTION
In https://github.com/cybozu-go/accurate/pull/99 I discovered that the `config.extraArgs` Helm value is not treated as a list when rendering the Deployment template - which makes it harder to use more than one extra argument to the workload. This PR fixes this.