### PR TITLE
feat: enable v2alpha1 API with conversion webhook

### DIFF
--- a/api/accurate/v1/subnamespace_conversion.go
+++ b/api/accurate/v1/subnamespace_conversion.go
@@ -21,7 +21,7 @@ func (src *SubNamespace) ConvertTo(dstRaw conversion.Hub) error {
 
 	logger := getConversionLogger(src).WithValues(
 		"source", SchemeGroupVersion.Version,
-		"destination", SchemeGroupVersion.Version,
+		"destination", accuratev2alpha1.SchemeGroupVersion.Version,
 	)
 	logger.V(5).Info("converting")
 
@@ -57,7 +57,7 @@ func (dst *SubNamespace) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*accuratev2alpha1.SubNamespace)
 
 	logger := getConversionLogger(src).WithValues(
-		"source", SchemeGroupVersion.Version,
+		"source", accuratev2alpha1.SchemeGroupVersion.Version,
 		"destination", SchemeGroupVersion.Version,
 	)
 	logger.V(5).Info("converting")

--- a/api/accurate/v2alpha1/subnamespace_types.go
+++ b/api/accurate/v2alpha1/subnamespace_types.go
@@ -31,8 +31,6 @@ type SubNamespaceSpec struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
-// Keeping this version un-served for now
-//+kubebuilder:unservedversion
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+genclient

--- a/charts/accurate/templates/generated/crds.yaml
+++ b/charts/accurate/templates/generated/crds.yaml
@@ -3,14 +3,25 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ template "accurate.fullname" . }}-serving-cert'
     controller-gen.kubebuilder.io/version: v0.12.0
   labels:
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
-    app.kubernetes.io/name: accurate
+    app.kubernetes.io/name: '{{ include "accurate.name" . }}'
     app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
     helm.sh/chart: '{{ include "accurate.chart" . }}'
   name: subnamespaces.accurate.cybozu.com
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: '{{ template "accurate.fullname" . }}-webhook-service'
+          namespace: '{{ .Release.Namespace }}'
+          path: /convert
+      conversionReviewVersions:
+        - v1
   group: accurate.cybozu.com
   names:
     kind: SubNamespace
@@ -138,7 +149,7 @@ spec:
                   type: integer
               type: object
           type: object
-      served: false
+      served: true
       storage: false
       subresources:
         status: {}

--- a/cmd/accurate-controller/sub/run.go
+++ b/cmd/accurate-controller/sub/run.go
@@ -9,6 +9,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	accuratev1 "github.com/cybozu-go/accurate/api/accurate/v1"
+	accuratev2alpha1 "github.com/cybozu-go/accurate/api/accurate/v2alpha1"
 	"github.com/cybozu-go/accurate/controllers"
 	"github.com/cybozu-go/accurate/hooks"
 	"github.com/cybozu-go/accurate/pkg/config"
@@ -35,7 +36,10 @@ func subMain(ns, addr string, port int) error {
 		return fmt.Errorf("unable to add client-go objects: %w", err)
 	}
 	if err := accuratev1.AddToScheme(scheme); err != nil {
-		return fmt.Errorf("unable to add Accurate objects: %w", err)
+		return fmt.Errorf("unable to add Accurate v1 objects: %w", err)
+	}
+	if err := accuratev2alpha1.AddToScheme(scheme); err != nil {
+		return fmt.Errorf("unable to add Accurate v2alpha1 objects: %w", err)
 	}
 
 	cfgData, err := os.ReadFile(options.configFile)

--- a/cmd/kubectl-accurate/sub/util.go
+++ b/cmd/kubectl-accurate/sub/util.go
@@ -2,6 +2,7 @@ package sub
 
 import (
 	accuratev1 "github.com/cybozu-go/accurate/api/accurate/v1"
+	accuratev2alpha1 "github.com/cybozu-go/accurate/api/accurate/v2alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -19,6 +20,9 @@ func makeClient(config *genericclioptions.ConfigFlags) (client.Client, error) {
 		return nil, err
 	}
 	if err := accuratev1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := accuratev2alpha1.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 

--- a/config/crd/bases/accurate.cybozu.com_subnamespaces.yaml
+++ b/config/crd/bases/accurate.cybozu.com_subnamespaces.yaml
@@ -155,7 +155,7 @@ spec:
                 type: integer
             type: object
         type: object
-    served: false
+    served: true
     storage: false
     subresources:
       status: {}

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -6,4 +6,10 @@ resources:
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:
+- patches/cainjection_in_subnamespaces.yaml
 - patches/fix-crd.yaml
+- patches/webhook_in_subnamespaces.yaml
+
+# the following config is for teaching kustomize how to do kustomization for CRDs.
+configurations:
+- kustomizeconfig.yaml

--- a/config/crd/kustomizeconfig.yaml
+++ b/config/crd/kustomizeconfig.yaml
@@ -1,0 +1,19 @@
+# This file is for teaching kustomize how to substitute name and namespace reference in CRD
+nameReference:
+  - kind: Service
+    version: v1
+    fieldSpecs:
+      - kind: CustomResourceDefinition
+        version: v1
+        group: apiextensions.k8s.io
+        path: spec/conversion/webhook/clientConfig/service/name
+
+namespace:
+  - kind: CustomResourceDefinition
+    version: v1
+    group: apiextensions.k8s.io
+    path: spec/conversion/webhook/clientConfig/service/namespace
+    create: false
+
+varReference:
+  - path: metadata/annotations

--- a/config/crd/patches/cainjection_in_subnamespaces.yaml
+++ b/config/crd/patches/cainjection_in_subnamespaces.yaml
@@ -1,0 +1,7 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: subnamespaces.accurate.cybozu.com

--- a/config/crd/patches/webhook_in_subnamespaces.yaml
+++ b/config/crd/patches/webhook_in_subnamespaces.yaml
@@ -1,0 +1,16 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: subnamespaces.accurate.cybozu.com
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-service
+          namespace: system
+          path: /convert
+      conversionReviewVersions:
+        - v1

--- a/config/kustomize-to-helm/overlays/crds/crd_conversion_patch.yaml
+++ b/config/kustomize-to-helm/overlays/crds/crd_conversion_patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ template "accurate.fullname" . }}-serving-cert'
+  name: subnamespaces.accurate.cybozu.com
+spec:
+  conversion:
+    webhook:
+      clientConfig:
+        service:
+          name: '{{ template "accurate.fullname" . }}-webhook-service'
+          namespace: '{{ .Release.Namespace }}'

--- a/config/kustomize-to-helm/overlays/crds/kustomization.yaml
+++ b/config/kustomize-to-helm/overlays/crds/kustomization.yaml
@@ -1,8 +1,8 @@
 resources:
   - ../../../crd
 
-commonLabels:
-  app.kubernetes.io/name: accurate
+patchesStrategicMerge:
+  - crd_conversion_patch.yaml
 
 components:
   - ../../components/common-labels

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	accuratev1 "github.com/cybozu-go/accurate/api/accurate/v1"
+	accuratev2alpha1 "github.com/cybozu-go/accurate/api/accurate/v2alpha1"
 	"github.com/cybozu-go/accurate/pkg/config"
 	"github.com/cybozu-go/accurate/pkg/constants"
 	"github.com/cybozu-go/accurate/pkg/feature"
@@ -69,6 +70,8 @@ var _ = BeforeSuite(func() {
 	err = clientgoscheme.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = accuratev1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = accuratev2alpha1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -308,6 +308,14 @@ var _ = Describe("kubectl accurate", func() {
 		}).Should(Succeed())
 	})
 
+	It("should convert SubNamespace to new version", func() {
+		kubectlSafe(nil, "create", "ns", "rootv2")
+		kubectlSafe(nil, "accurate", "ns", "set-type", "rootv2", "root")
+		kubectlSafe(nil, "accurate", "sub", "create", "subv2", "rootv2")
+		kubectlSafe(nil, "get", "subnamespaces", "-n", "rootv2", "subv2")
+		kubectlSafe(nil, "get", "subnamespaces.v2alpha1.accurate.cybozu.com", "-n", "rootv2", "subv2")
+	})
+
 	It("should run other commands", func() {
 		kubectlSafe(nil, "accurate", "list")
 		kubectlSafe(nil, "accurate", "sub", "list")

--- a/hooks/suite_test.go
+++ b/hooks/suite_test.go
@@ -15,6 +15,7 @@ import (
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	//+kubebuilder:scaffold:imports
 	accuratev1 "github.com/cybozu-go/accurate/api/accurate/v1"
+	accuratev2alpha1 "github.com/cybozu-go/accurate/api/accurate/v2alpha1"
 	"github.com/cybozu-go/accurate/pkg/config"
 	"github.com/cybozu-go/accurate/pkg/indexing"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -63,6 +64,8 @@ var _ = BeforeSuite(func() {
 
 	scheme := runtime.NewScheme()
 	err = accuratev1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = accuratev2alpha1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = clientgoscheme.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This PR makes the new v2alpha1 version of the API served and enables the conversion webhook using logic established in https://github.com/cybozu-go/accurate/pull/96.

After this, I will suggest changing the SubNamespace controller to watch/reconcile version v1alpha1 (using SSA). When the controller watches v2alpha1 version, I think it also makes sense to switch the stored version.