### PR TITLE
chore: ensure webhooks are handling all API versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ help: ## Display this help.
 HELM_CRDS_FILE := charts/accurate/templates/generated/crds.yaml
 .PHONY: manifests
 manifests: setup ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	controller-gen $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="{./api/..., ./controllers/...}" output:crd:artifacts:config=config/crd/bases
+	controller-gen $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="{./api/..., ./controllers/..., ./hooks/...}" output:crd:artifacts:config=config/crd/bases
 	echo '{{- if .Values.installCRDs }}' > $(HELM_CRDS_FILE)
 	kustomize build config/kustomize-to-helm/overlays/crds | yq e "." -p yaml - >> $(HELM_CRDS_FILE)
 	echo '{{- end }}' >> $(HELM_CRDS_FILE)

--- a/charts/accurate/templates/generated/generated.yaml
+++ b/charts/accurate/templates/generated/generated.yaml
@@ -233,6 +233,7 @@ webhooks:
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-accurate-cybozu-com-v1-subnamespace
     failurePolicy: Fail
+    matchPolicy: Equivalent
     name: subnamespace.accurate.cybozu.io
     rules:
       - apiGroups:
@@ -287,6 +288,7 @@ webhooks:
         namespace: '{{ .Release.Namespace }}'
         path: /validate-accurate-cybozu-com-v1-subnamespace
     failurePolicy: Fail
+    matchPolicy: Equivalent
     name: vsubnamespace.kb.io
     rules:
       - apiGroups:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -12,6 +12,7 @@ webhooks:
       namespace: system
       path: /mutate-accurate-cybozu-com-v1-subnamespace
   failurePolicy: Fail
+  matchPolicy: Equivalent
   name: subnamespace.accurate.cybozu.io
   rules:
   - apiGroups:
@@ -59,6 +60,7 @@ webhooks:
       namespace: system
       path: /validate-accurate-cybozu-com-v1-subnamespace
   failurePolicy: Fail
+  matchPolicy: Equivalent
   name: vsubnamespace.kb.io
   rules:
   - apiGroups:

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.25.0
 	k8s.io/api v0.28.2
+	k8s.io/apiextensions-apiserver v0.28.2
 	k8s.io/apimachinery v0.28.2
 	k8s.io/cli-runtime v0.28.2
 	k8s.io/client-go v0.28.2
@@ -19,6 +20,8 @@ require (
 	k8s.io/klog/v2 v2.100.1
 	sigs.k8s.io/cli-utils v0.35.0
 	sigs.k8s.io/controller-runtime v0.16.2
+	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3
+	sigs.k8s.io/kustomize/kyaml v0.14.3-0.20230601165947-6ce0bf390ce3
 	sigs.k8s.io/structured-merge-diff/v4 v4.3.0
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -82,10 +85,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.28.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20230918164632-68afd615200d // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
-	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.14.3-0.20230601165947-6ce0bf390ce3 // indirect
 )

--- a/hooks/subnamespace.go
+++ b/hooks/subnamespace.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-//+kubebuilder:webhook:path=/mutate-accurate-cybozu-com-v1-subnamespace,mutating=true,failurePolicy=fail,sideEffects=None,groups=accurate.cybozu.com,resources=subnamespaces,verbs=create;update,versions=v1,name=subnamespace.accurate.cybozu.io,admissionReviewVersions={v1}
+//+kubebuilder:webhook:path=/mutate-accurate-cybozu-com-v1-subnamespace,mutating=true,failurePolicy=fail,sideEffects=None,groups=accurate.cybozu.com,resources=subnamespaces,verbs=create;update,versions=v1,matchPolicy=Equivalent,name=subnamespace.accurate.cybozu.io,admissionReviewVersions={v1}
 
 type subNamespaceMutator struct {
 	dec *admission.Decoder
@@ -52,7 +52,7 @@ func (m *subNamespaceMutator) Handle(ctx context.Context, req admission.Request)
 	return admission.PatchResponseFromRaw(req.Object.Raw, data)
 }
 
-//+kubebuilder:webhook:path=/validate-accurate-cybozu-com-v1-subnamespace,mutating=false,failurePolicy=fail,sideEffects=None,groups=accurate.cybozu.com,resources=subnamespaces,verbs=create;update,versions=v1,name=vsubnamespace.kb.io,admissionReviewVersions={v1}
+//+kubebuilder:webhook:path=/validate-accurate-cybozu-com-v1-subnamespace,mutating=false,failurePolicy=fail,sideEffects=None,groups=accurate.cybozu.com,resources=subnamespaces,verbs=create;update,versions=v1,matchPolicy=Equivalent,name=vsubnamespace.kb.io,admissionReviewVersions={v1}
 
 type subNamespaceValidator struct {
 	client.Client

--- a/hooks/subnamespace_test.go
+++ b/hooks/subnamespace_test.go
@@ -3,11 +3,14 @@ package hooks
 import (
 	"context"
 
-	accuratev1 "github.com/cybozu-go/accurate/api/accurate/v1"
-	"github.com/cybozu-go/accurate/pkg/constants"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	accuratev1 "github.com/cybozu-go/accurate/api/accurate/v1"
+	"github.com/cybozu-go/accurate/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -26,6 +29,7 @@ var _ = Describe("SubNamespace webhook", func() {
 		sn.Name = "foo"
 		err = k8sClient.Create(ctx, sn)
 		Expect(err).To(HaveOccurred())
+		Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 	})
 
 	It("should allow creation of SubNamespace in a root namespace", func() {
@@ -45,7 +49,7 @@ var _ = Describe("SubNamespace webhook", func() {
 
 		Expect(controllerutil.ContainsFinalizer(sn, constants.Finalizer)).To(BeTrue())
 
-		// deleting finalizer should succeeds
+		// deleting finalizer should succeed
 		sn.Finalizers = nil
 		err = k8sClient.Update(ctx, sn)
 		Expect(err).NotTo(HaveOccurred())
@@ -185,6 +189,7 @@ var _ = Describe("SubNamespace webhook", func() {
 					sn.Name = "naming-policy-root-2--child"
 					err = k8sClient.Create(ctx, sn)
 					Expect(err).To(HaveOccurred())
+					Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 				})
 
 				It("should deny creation of SubNamespace in a root namespace - pattern2", func() {
@@ -199,6 +204,7 @@ var _ = Describe("SubNamespace webhook", func() {
 					sn.Name = "child-2"
 					err = k8sClient.Create(ctx, sn)
 					Expect(err).To(HaveOccurred())
+					Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 				})
 
 				It("should deny creation of SubNamespace in a root namespace - pattern3", func() {
@@ -219,6 +225,7 @@ var _ = Describe("SubNamespace webhook", func() {
 					sn.Name = "not-ns-root-2-parent-child"
 					err = k8sClient.Create(ctx, sn)
 					Expect(err).To(HaveOccurred())
+					Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 				})
 
 				It("should deny creation of SubNamespace in a root namespace - pattern4", func() {
@@ -233,6 +240,7 @@ var _ = Describe("SubNamespace webhook", func() {
 					sn.Name = "app-team20-child"
 					err = k8sClient.Create(ctx, sn)
 					Expect(err).To(HaveOccurred())
+					Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 				})
 
 				It("should deny creation of SubNamespace in a root namespace - pattern5", func() {
@@ -247,6 +255,7 @@ var _ = Describe("SubNamespace webhook", func() {
 					sn.Name = "unuse-naming-group-team2-foo"
 					err = k8sClient.Create(ctx, sn)
 					Expect(err).To(HaveOccurred())
+					Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 				})
 
 				It("should deny creation of SubNamespace in a root namespace - pattern6", func() {
@@ -262,6 +271,7 @@ var _ = Describe("SubNamespace webhook", func() {
 					sn.Spec.Labels = map[string]string{"foo": "~"}
 					err = k8sClient.Create(ctx, sn)
 					Expect(err).To(HaveOccurred())
+					Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 				})
 
 				It("should deny creation of SubNamespace in a root namespace - pattern7", func() {
@@ -277,6 +287,7 @@ var _ = Describe("SubNamespace webhook", func() {
 					sn.Spec.Annotations = map[string]string{"foo-": ""}
 					err = k8sClient.Create(ctx, sn)
 					Expect(err).To(HaveOccurred())
+					Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 				})
 
 				It("should deny creation of SubNamespace in a root namespace - pattern8", func() {
@@ -293,6 +304,7 @@ var _ = Describe("SubNamespace webhook", func() {
 					sn.Spec.Annotations = map[string]string{"foo-": ""}
 					err = k8sClient.Create(ctx, sn)
 					Expect(err).To(HaveOccurred())
+					Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 				})
 			})
 		})

--- a/hooks/subnamespace_v2_test.go
+++ b/hooks/subnamespace_v2_test.go
@@ -1,0 +1,64 @@
+package hooks
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	accuratev2alpha1 "github.com/cybozu-go/accurate/api/accurate/v2alpha1"
+	"github.com/cybozu-go/accurate/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// This is just simple smoke tests ensuring our webhooks are handling additional versions of the SubNamespace API.
+var _ = Describe("SubNamespace webhook", func() {
+	ctx := context.Background()
+
+	It("should deny creation of v2 SubNamespace in a namespace that is neither root nor subnamespace", func() {
+		ns := &corev1.Namespace{}
+		ns.Name = "v2alpha1-ns1"
+		err := k8sClient.Create(ctx, ns)
+		Expect(err).NotTo(HaveOccurred())
+
+		sn := &accuratev2alpha1.SubNamespace{}
+		sn.Namespace = "v2alpha1-ns1"
+		sn.Name = "v2alpha1-foo"
+		err = k8sClient.Create(ctx, sn)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
+	})
+
+	It("should allow creation of SubNamespace in a root namespace", func() {
+		ns := &corev1.Namespace{}
+		ns.Name = "v2alpha1-ns2"
+		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
+		err := k8sClient.Create(ctx, ns)
+		Expect(err).To(Succeed())
+
+		sn := &accuratev2alpha1.SubNamespace{}
+		sn.Namespace = "v2alpha1-ns2"
+		sn.Name = "v2alpha1-foo"
+		sn.Spec.Labels = map[string]string{"foo": "bar"}
+		sn.Spec.Annotations = map[string]string{"foo": "bar"}
+		err = k8sClient.Create(ctx, sn)
+		Expect(err).To(Succeed())
+
+		Expect(controllerutil.ContainsFinalizer(sn, constants.Finalizer)).To(BeTrue())
+
+		// deleting finalizer should succeed
+		sn.Finalizers = nil
+		err = k8sClient.Update(ctx, sn)
+		Expect(err).To(Succeed())
+
+		sn = &accuratev2alpha1.SubNamespace{}
+		err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "v2alpha1-ns2", Name: "v2alpha1-foo"}, sn)
+		Expect(err).To(Succeed())
+		Expect(sn.Finalizers).To(BeEmpty())
+	})
+
+})


### PR DESCRIPTION
First I want to clarify that this PR does not fix any problem. 😉 I just felt uncertain if the webhooks were addressing the new (and now served) `SubNamespace` API version. But they do - since the default `matchPolicy` in webhooks is `Equivalent`. Since I already made an effort to check this with tests, I think my changes could be added as an improvement to the hooks tests. It is probably unlikely, but if we want to test webhooks for different behavior between versions, this is possible now. 

Also configured `matchPolicy` explicitly in webhook configuration resources, which I think makes sense now, as we have to ensure the webhooks address all versions.