### PR TITLE
chore: migrate controllers to SSA

### DIFF
--- a/controllers/ssa_client.go
+++ b/controllers/ssa_client.go
@@ -1,0 +1,44 @@
+package controllers
+
+import (
+	"encoding/json"
+
+	accuratev2alpha1 "github.com/cybozu-go/accurate/api/accurate/v2alpha1"
+	accuratev2alpha1ac "github.com/cybozu-go/accurate/internal/applyconfigurations/accurate/v2alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	fieldOwner client.FieldOwner = "accurate-controller"
+)
+
+func newSubNamespacePatch(ac *accuratev2alpha1ac.SubNamespaceApplyConfiguration) (*accuratev2alpha1.SubNamespace, client.Patch, error) {
+	sn := &accuratev2alpha1.SubNamespace{}
+	sn.Name = *ac.Name
+	sn.Namespace = *ac.Namespace
+
+	return sn, applyPatch{ac}, nil
+}
+
+func newNamespacePatch(ac *corev1ac.NamespaceApplyConfiguration) (*corev1.Namespace, client.Patch, error) {
+	ns := &corev1.Namespace{}
+	ns.Name = *ac.Name
+
+	return ns, applyPatch{ac}, nil
+}
+
+type applyPatch struct {
+	// must use any type until apply configurations implements a common interface
+	patch any
+}
+
+func (p applyPatch) Type() types.PatchType {
+	return types.ApplyPatchType
+}
+
+func (p applyPatch) Data(_ client.Object) ([]byte, error) {
+	return json.Marshal(p.patch)
+}

--- a/docs/subnamespaces.md
+++ b/docs/subnamespaces.md
@@ -30,7 +30,7 @@ metadata:
     team: foo
 ```
 
-Accurate only propagates labels/annotations that have been configured in that respect via the `labelKeys` and `annotationKeys` parameters in `config.yaml`. This prevents the propagation of labels/annotations that were not meant to do so. Accurate currently does not delete previously propagated labels when deleted from the parent namespace to prevent unintended deletions. Users are expected to manually delete labels/annotations that are no longer needed.
+Accurate only propagates labels/annotations that have been configured in that respect via the `labelKeys` and `annotationKeys` parameters in `config.yaml`. This prevents the propagation of labels/annotations that were not meant to do so.
 
 ### Preparing resources for tenant users
 


### PR DESCRIPTION
This PR migrates all updates in controllers to server-side apply (SSA), except the update removing the finalizer on SubNamespace - which is changed to a standard patch.

SSA works a bit differently than updates, so some of the optimizations had to go in this PR. I am hoping this change won't increase the load on the api-server significantly, but it's something we should monitor. I have added stable resource version tests for namespaces - which are now SSAed unconditionally.

Namespace controller tests are currently highly scenario-based, which makes them long and hard to read/modify. I have added some additional assertions of modified behavior on migration to SSA, but I suggest refactoring the tests in a follow-up PR to improve the test coverage. I can prepare a PR if you agree.

Fixes #98 