### PR TITLE
chore: deprecate user-facing propagate-generated annotation

### DIFF
--- a/controllers/propagate_test.go
+++ b/controllers/propagate_test.go
@@ -364,6 +364,7 @@ var _ = Describe("SubNamespace controller", func() {
 		cm1 := &corev1.ConfigMap{}
 		cm1.Namespace = rootNS
 		cm1.Name = "cm-generate"
+		//lint:ignore SA1019 subject for removal
 		cm1.Annotations = map[string]string{constants.AnnPropagateGenerated: constants.PropagateUpdate}
 		cm1.Data = map[string]string{"foo": "bar"}
 		err := k8sClient.Create(ctx, cm1)

--- a/pkg/constants/meta.go
+++ b/pkg/constants/meta.go
@@ -16,8 +16,10 @@ const (
 
 // Annotations
 const (
-	AnnFrom               = MetaPrefix + "from"
-	AnnPropagate          = MetaPrefix + "propagate"
+	AnnFrom      = MetaPrefix + "from"
+	AnnPropagate = MetaPrefix + "propagate"
+	// Deprecated: Part of the deprecated propagate-generated feature subject for
+	// removal soon.
 	AnnPropagateGenerated = MetaPrefix + "propagate-generated"
 	// Deprecated: Part of the deprecated propagate-generated feature subject for
 	// removal soon.


### PR DESCRIPTION
This fixes a leftover after https://github.com/cybozu-go/accurate/pull/95. Somehow we forgot to deprecate the user-facing annotation for the now deprecated propagate-generated feature.