### PR TITLE
test: migrate envtests to komega

### DIFF
--- a/controllers/propagate_test.go
+++ b/controllers/propagate_test.go
@@ -13,10 +13,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
@@ -42,15 +42,12 @@ var _ = Describe("SubNamespace controller", func() {
 
 	BeforeEach(func() {
 		for _, ns := range []string{rootNS, sub1NS, sub2NS, sub1SubNS} {
-			err := k8sClient.DeleteAllOf(ctx, &corev1.ConfigMap{}, client.InNamespace(ns))
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.DeleteAllOf(ctx, &corev1.ConfigMap{}, client.InNamespace(ns))).To(Succeed())
 		}
 		svcList := &corev1.ServiceList{}
-		err := k8sClient.List(ctx, svcList)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.List(ctx, svcList)).To(Succeed())
 		for i := range svcList.Items {
-			err := k8sClient.Delete(ctx, &svcList.Items[i])
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Delete(ctx, &svcList.Items[i])).To(Succeed())
 		}
 
 		mgr, err := ctrl.NewManager(k8sCfg, ctrl.Options{
@@ -93,38 +90,35 @@ var _ = Describe("SubNamespace controller", func() {
 		svc1.Annotations = map[string]string{constants.AnnPropagate: constants.PropagateCreate}
 		svc1.Spec.ClusterIP = "None"
 		svc1.Spec.Ports = []corev1.ServicePort{{Port: 3333, TargetPort: intstr.FromInt(3333)}}
-		err := k8sClient.Create(ctx, svc1)
-		Expect(err).NotTo(HaveOccurred())
-		svc1.Status.Conditions = []metav1.Condition{{
-			Type:               "foo",
-			Status:             metav1.ConditionTrue,
-			LastTransitionTime: metav1.Now(),
-			Reason:             "Foo",
-			Message:            "blah",
-		}}
-		err = k8sClient.Status().Update(ctx, svc1)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, svc1)).To(Succeed())
+		Expect(komega.UpdateStatus(svc1, func() {
+			svc1.Status.Conditions = []metav1.Condition{{
+				Type:               "foo",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "Foo",
+				Message:            "blah",
+			}}
+		})()).To(Succeed())
 
 		svc2 := &corev1.Service{}
 		svc2.Namespace = rootNS
 		svc2.Name = "svc2"
 		svc2.Spec.Ports = []corev1.ServicePort{{Port: 3333, TargetPort: intstr.FromInt(3333)}}
-		err = k8sClient.Create(ctx, svc2)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, svc2)).To(Succeed())
 
-		var svc1Sub1, svc1Sub2, svc1Sub1Sub *corev1.Service
-		Eventually(func() error {
-			svc1Sub1 = &corev1.Service{}
-			return k8sClient.Get(ctx, client.ObjectKey{Namespace: sub1NS, Name: "svc1"}, svc1Sub1)
-		}).Should(Succeed())
-		Eventually(func() error {
-			svc1Sub2 = &corev1.Service{}
-			return k8sClient.Get(ctx, client.ObjectKey{Namespace: sub2NS, Name: "svc1"}, svc1Sub2)
-		}).Should(Succeed())
-		Eventually(func() error {
-			svc1Sub1Sub = &corev1.Service{}
-			return k8sClient.Get(ctx, client.ObjectKey{Namespace: sub1SubNS, Name: "svc1"}, svc1Sub1Sub)
-		}).Should(Succeed())
+		svc1Sub1 := &corev1.Service{}
+		svc1Sub1.Name = "svc1"
+		svc1Sub1.Namespace = sub1NS
+		Eventually(komega.Get(svc1Sub1)).Should(Succeed())
+		svc1Sub2 := &corev1.Service{}
+		svc1Sub2.Name = "svc1"
+		svc1Sub2.Namespace = sub2NS
+		Eventually(komega.Get(svc1Sub2)).Should(Succeed())
+		svc1Sub1Sub := &corev1.Service{}
+		svc1Sub1Sub.Name = "svc1"
+		svc1Sub1Sub.Namespace = sub1SubNS
+		Eventually(komega.Get(svc1Sub1Sub)).Should(Succeed())
 		Expect(svc1Sub1.Annotations).To(HaveKeyWithValue(constants.AnnFrom, rootNS))
 		Expect(svc1Sub1.Spec.Ports).To(HaveLen(1))
 		Expect(svc1Sub1.Spec.Ports[0].Port).To(BeNumerically("==", 3333))
@@ -136,72 +130,38 @@ var _ = Describe("SubNamespace controller", func() {
 		Expect(svc1Sub1Sub.Spec.Ports[0].Port).To(BeNumerically("==", 3333))
 
 		svc2Sub1 := &corev1.Service{}
-		err = k8sClient.Get(ctx, client.ObjectKey{Namespace: sub1NS, Name: "svc2"}, svc2Sub1)
-		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		svc2Sub1.Name = "svc2"
+		svc2Sub1.Namespace = sub1NS
+		Expect(komega.Get(svc2Sub1)()).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 
 		By("deleting a sub-resource to check that Accurate re-creates it")
 		uid := svc1Sub2.UID
-		err = k8sClient.Delete(ctx, svc1Sub2)
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(func() types.UID {
-			svc := &corev1.Service{}
-			if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: sub2NS, Name: "svc1"}, svc); err != nil {
-				return uid
-			}
-			return svc.UID
-		}).ShouldNot(Equal(uid))
+		Expect(k8sClient.Delete(ctx, svc1Sub2)).To(Succeed())
+		Eventually(komega.Object(svc1Sub2)).Should(HaveField("UID", Not(Equal(uid))))
 
 		By("updating a sub-resource to check that Accurate won't fix it")
-		svc1Sub1.Annotations["hoge"] = "fuga"
-		err = k8sClient.Update(ctx, svc1Sub1)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(komega.Update(svc1Sub1, func() {
+			svc1Sub1.Annotations["hoge"] = "fuga"
+		})()).To(Succeed())
 
-		Eventually(func() string {
-			svc1Sub1 = &corev1.Service{}
-			if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: sub1NS, Name: "svc1"}, svc1Sub1); err != nil {
-				return ""
-			}
-			return svc1Sub1.Annotations["hoge"]
-		}).Should(Equal("fuga"))
-		Consistently(func() string {
-			svc1Sub1 = &corev1.Service{}
-			if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: sub1NS, Name: "svc1"}, svc1Sub1); err != nil {
-				return ""
-			}
-			return svc1Sub1.Annotations["hoge"]
-		}).Should(Equal("fuga"))
+		Eventually(komega.Object(svc1Sub1)).Should(HaveField("Annotations", HaveKeyWithValue("hoge", "fuga")))
+		Consistently(komega.Object(svc1Sub1)).Should(HaveField("Annotations", HaveKeyWithValue("hoge", "fuga")))
 
 		By("changing a sub-resource to a non-sub-resource")
-		svc1Sub1Sub.Annotations = map[string]string{
-			constants.AnnPropagate: constants.PropagateUpdate,
-		}
-		err = k8sClient.Update(ctx, svc1Sub1Sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(komega.Update(svc1Sub1Sub, func() {
+			svc1Sub1Sub.Annotations = map[string]string{
+				constants.AnnPropagate: constants.PropagateUpdate,
+			}
+		})()).To(Succeed())
 
-		Eventually(func() string {
-			svc1Sub1Sub = &corev1.Service{}
-			if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: sub1SubNS, Name: "svc1"}, svc1Sub1Sub); err != nil {
-				return ""
-			}
-			return svc1Sub1Sub.Annotations[constants.AnnPropagate]
-		}).Should(Equal(constants.PropagateUpdate))
-		Consistently(func() string {
-			svc1Sub1Sub = &corev1.Service{}
-			if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: sub1SubNS, Name: "svc1"}, svc1Sub1Sub); err != nil {
-				return ""
-			}
-			return svc1Sub1Sub.Annotations[constants.AnnPropagate]
-		}).Should(Equal(constants.PropagateUpdate))
+		Eventually(komega.Object(svc1Sub1Sub)).Should(HaveField("Annotations", HaveKeyWithValue(constants.AnnPropagate, constants.PropagateUpdate)))
+		Consistently(komega.Object(svc1Sub1Sub)).Should(HaveField("Annotations", HaveKeyWithValue(constants.AnnPropagate, constants.PropagateUpdate)))
 		Expect(svc1Sub1Sub.Annotations).NotTo(HaveKey(constants.AnnFrom))
 
 		By("deleting the root resource")
-		err = k8sClient.Delete(ctx, svc1)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Delete(ctx, svc1)).To(Succeed())
 
-		Consistently(func() error {
-			svc1Sub1 = &corev1.Service{}
-			return k8sClient.Get(ctx, client.ObjectKey{Namespace: sub1NS, Name: "svc1"}, svc1Sub1)
-		}).Should(Succeed())
+		Consistently(komega.Get(svc1Sub1)).Should(Succeed())
 		Expect(svc1Sub1.DeletionTimestamp).To(BeNil())
 	})
 
@@ -213,49 +173,40 @@ var _ = Describe("SubNamespace controller", func() {
 		svc1.Annotations = map[string]string{constants.AnnPropagate: constants.PropagateCreate}
 		svc1.Spec.ClusterIP = "None"
 		svc1.Spec.Ports = []corev1.ServicePort{{Port: 3333, TargetPort: intstr.FromInt(3333)}}
-		err := k8sClient.Create(ctx, svc1)
-		Expect(err).NotTo(HaveOccurred())
-		svc1.Status.Conditions = []metav1.Condition{{
-			Type:               "foo",
-			Status:             metav1.ConditionTrue,
-			LastTransitionTime: metav1.Now(),
-			Reason:             "Foo",
-			Message:            "blah",
-		}}
-		err = k8sClient.Status().Update(ctx, svc1)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, svc1)).To(Succeed())
+		Expect(komega.UpdateStatus(svc1, func() {
+			svc1.Status.Conditions = []metav1.Condition{{
+				Type:               "foo",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "Foo",
+				Message:            "blah",
+			}}
+		})()).To(Succeed())
 
 		svc2 := &corev1.Service{}
 		svc2.Namespace = tmplNS
 		svc2.Name = "svc2"
 		svc2.Spec.Ports = []corev1.ServicePort{{Port: 3333, TargetPort: intstr.FromInt(3333)}}
-		err = k8sClient.Create(ctx, svc2)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, svc2)).To(Succeed())
 
-		var svc1Instance *corev1.Service
-		Eventually(func() error {
-			svc1Instance = &corev1.Service{}
-			return k8sClient.Get(ctx, client.ObjectKey{Namespace: instanceNS, Name: "svc1"}, svc1Instance)
-		}).Should(Succeed())
+		svc1Instance := &corev1.Service{}
+		svc1Instance.Name = "svc1"
+		svc1Instance.Namespace = instanceNS
+		Eventually(komega.Get(svc1Instance)).Should(Succeed())
 		Expect(svc1Instance.Annotations).To(HaveKeyWithValue(constants.AnnFrom, tmplNS))
 		Expect(svc1Instance.Spec.Ports).To(HaveLen(1))
 		Expect(svc1Instance.Spec.Ports[0].Port).To(BeNumerically("==", 3333))
 
 		svc2Instance := &corev1.Service{}
-		err = k8sClient.Get(ctx, client.ObjectKey{Namespace: instanceNS, Name: "svc2"}, svc2Instance)
-		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		svc2Instance.Name = "svc2"
+		svc2Instance.Namespace = instanceNS
+		Expect(komega.Get(svc2Instance)()).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 
 		By("deleting a sub-resource to check that Accurate re-creates it")
 		uid := svc1Instance.UID
-		err = k8sClient.Delete(ctx, svc1Instance)
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(func() types.UID {
-			svc1Instance = &corev1.Service{}
-			if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: instanceNS, Name: "svc1"}, svc1Instance); err != nil {
-				return uid
-			}
-			return svc1Instance.UID
-		}).ShouldNot(Equal(uid))
+		Expect(k8sClient.Delete(ctx, svc1Instance)).To(Succeed())
+		Eventually(komega.Object(svc1Instance)).Should(HaveField("UID", Not(Equal(uid))))
 	})
 
 	It("should propagate resources for mode=update", func() {
@@ -266,31 +217,29 @@ var _ = Describe("SubNamespace controller", func() {
 		svc1.Annotations = map[string]string{constants.AnnPropagate: constants.PropagateUpdate}
 		svc1.Spec.ClusterIP = "None"
 		svc1.Spec.Ports = []corev1.ServicePort{{Port: 3333, TargetPort: intstr.FromInt(3333)}}
-		err := k8sClient.Create(ctx, svc1)
-		Expect(err).NotTo(HaveOccurred())
-		svc1.Status.Conditions = []metav1.Condition{{
-			Type:               "foo",
-			Status:             metav1.ConditionTrue,
-			LastTransitionTime: metav1.Now(),
-			Reason:             "Foo",
-			Message:            "blah",
-		}}
-		err = k8sClient.Status().Update(ctx, svc1)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, svc1)).To(Succeed())
+		Expect(komega.UpdateStatus(svc1, func() {
+			svc1.Status.Conditions = []metav1.Condition{{
+				Type:               "foo",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "Foo",
+				Message:            "blah",
+			}}
+		})()).To(Succeed())
 
-		var svc1Sub1, svc1Sub2, svc1Sub1Sub *corev1.Service
-		Eventually(func() error {
-			svc1Sub1 = &corev1.Service{}
-			return k8sClient.Get(ctx, client.ObjectKey{Namespace: sub1NS, Name: "svc1"}, svc1Sub1)
-		}).Should(Succeed())
-		Eventually(func() error {
-			svc1Sub2 = &corev1.Service{}
-			return k8sClient.Get(ctx, client.ObjectKey{Namespace: sub2NS, Name: "svc1"}, svc1Sub2)
-		}).Should(Succeed())
-		Eventually(func() error {
-			svc1Sub1Sub = &corev1.Service{}
-			return k8sClient.Get(ctx, client.ObjectKey{Namespace: sub1SubNS, Name: "svc1"}, svc1Sub1Sub)
-		}).Should(Succeed())
+		svc1Sub1 := &corev1.Service{}
+		svc1Sub1.Name = "svc1"
+		svc1Sub1.Namespace = sub1NS
+		Eventually(komega.Get(svc1Sub1)).Should(Succeed())
+		svc1Sub2 := &corev1.Service{}
+		svc1Sub2.Name = "svc1"
+		svc1Sub2.Namespace = sub2NS
+		Eventually(komega.Get(svc1Sub2)).Should(Succeed())
+		svc1Sub1Sub := &corev1.Service{}
+		svc1Sub1Sub.Name = "svc1"
+		svc1Sub1Sub.Namespace = sub1SubNS
+		Eventually(komega.Get(svc1Sub1Sub)).Should(Succeed())
 		Expect(svc1Sub1.Annotations).To(HaveKeyWithValue(constants.AnnFrom, rootNS))
 		Expect(svc1Sub1.Spec.Ports).To(HaveLen(1))
 		Expect(svc1Sub1.Spec.Ports[0].Port).To(BeNumerically("==", 3333))
@@ -303,60 +252,40 @@ var _ = Describe("SubNamespace controller", func() {
 
 		By("deleting a sub-resource to check that Accurate re-creates it")
 		uid := svc1Sub2.UID
-		err = k8sClient.Delete(ctx, svc1Sub2)
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(func() types.UID {
-			svc := &corev1.Service{}
-			if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: sub2NS, Name: "svc1"}, svc); err != nil {
-				return uid
-			}
-			return svc.UID
-		}).ShouldNot(Equal(uid))
+		Expect(k8sClient.Delete(ctx, svc1Sub2)).To(Succeed())
+		Eventually(komega.Object(svc1Sub2)).Should(HaveField("UID", Not(Equal(uid))))
 
 		By("updating a sub-resource to check that Accurate fixes it")
-		svc1Sub1.Annotations[constants.AnnPropagate] = constants.PropagateCreate
-		err = k8sClient.Update(ctx, svc1Sub1)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(komega.Update(svc1Sub1, func() {
+			svc1Sub1.Annotations[constants.AnnPropagate] = constants.PropagateCreate
+		})()).To(Succeed())
 		rv := svc1Sub1.ResourceVersion
 		rv2 := svc1Sub1Sub.ResourceVersion
-		Eventually(func() string {
-			svc1Sub1 = &corev1.Service{}
-			if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: sub1NS, Name: "svc1"}, svc1Sub1); err != nil {
-				return rv
-			}
-			return svc1Sub1.ResourceVersion
-		}).ShouldNot(Equal(rv))
+		Eventually(komega.Object(svc1Sub1)).Should(HaveField("ResourceVersion", Not(Equal(rv))))
 		Expect(svc1Sub1.Annotations).To(HaveKeyWithValue(constants.AnnPropagate, constants.PropagateUpdate))
 		time.Sleep(100 * time.Millisecond)
 		Expect(svc1Sub1Sub.ResourceVersion).To(Equal(rv2))
 
 		By("updating a root resource to check that Accurate propagates the change to sub-resources")
-		svc1.Labels = map[string]string{"foo": "bar"}
-		err = k8sClient.Update(ctx, svc1)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(komega.Update(svc1, func() {
+			svc1.Labels = map[string]string{"foo": "bar"}
+		})()).To(Succeed())
 
 		for _, ns := range []string{sub1NS, sub2NS, sub1SubNS} {
-			Eventually(func() string {
-				svc := &corev1.Service{}
-				if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: "svc1"}, svc); err != nil {
-					return ""
-				}
-				return svc.Labels["foo"]
-			}).Should(Equal("bar"))
+			svc := &corev1.Service{}
+			svc.Name = "svc1"
+			svc.Namespace = ns
+			Eventually(komega.Object(svc)).Should(HaveField("Labels", HaveKeyWithValue("foo", "bar")))
 		}
 
 		By("deleting a root resource to check that Accurate cascades the deletion")
-		err = k8sClient.Delete(ctx, svc1)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Delete(ctx, svc1)).To(Succeed())
 
 		for _, ns := range []string{sub1NS, sub2NS, sub1SubNS} {
-			Eventually(func() bool {
-				svc := &corev1.Service{}
-				if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: "svc1"}, svc); err != nil {
-					return apierrors.IsNotFound(err)
-				}
-				return false
-			}).Should(BeTrue())
+			svc := &corev1.Service{}
+			svc.Name = "svc1"
+			svc.Namespace = ns
+			Eventually(komega.Get(svc)).Should(WithTransform(apierrors.IsNotFound, BeTrue()))
 		}
 	})
 
@@ -367,15 +296,13 @@ var _ = Describe("SubNamespace controller", func() {
 		//lint:ignore SA1019 subject for removal
 		cm1.Annotations = map[string]string{constants.AnnPropagateGenerated: constants.PropagateUpdate}
 		cm1.Data = map[string]string{"foo": "bar"}
-		err := k8sClient.Create(ctx, cm1)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, cm1)).To(Succeed())
 
 		cm2 := &corev1.ConfigMap{}
 		cm2.Namespace = rootNS
 		cm2.Name = "cm-no-generate"
 		cm2.Data = map[string]string{"abc": "def"}
-		err = k8sClient.Create(ctx, cm2)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, cm2)).To(Succeed())
 
 		svc1 := &corev1.Service{}
 		svc1.Namespace = rootNS
@@ -383,35 +310,21 @@ var _ = Describe("SubNamespace controller", func() {
 		ctrl.SetControllerReference(cm1, svc1, scheme)
 		svc1.Spec.ClusterIP = "None"
 		svc1.Spec.Ports = []corev1.ServicePort{{Port: 3333, TargetPort: intstr.FromInt(3333)}}
-		err = k8sClient.Create(ctx, svc1)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, svc1)).To(Succeed())
 
-		Eventually(func() string {
-			svc1 = &corev1.Service{}
-			if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: rootNS, Name: "svc1"}, svc1); err != nil {
-				return ""
-			}
-			return svc1.Annotations[constants.AnnPropagate]
-		}).Should(Equal(constants.PropagateUpdate))
+		Eventually(komega.Object(svc1)).Should(HaveField("Annotations", HaveKeyWithValue(constants.AnnPropagate, constants.PropagateUpdate)))
 		//lint:ignore SA1019 subject for removal
 		Expect(svc1.Annotations).NotTo(HaveKey(constants.AnnGenerated))
 
 		svc2 := &corev1.Service{}
 		svc2.Namespace = rootNS
 		svc2.Name = "svc2"
-		ctrl.SetControllerReference(cm2, svc2, scheme)
+		Expect(ctrl.SetControllerReference(cm2, svc2, scheme)).To(Succeed())
 		svc2.Spec.ClusterIP = "None"
 		svc2.Spec.Ports = []corev1.ServicePort{{Port: 3333, TargetPort: intstr.FromInt(3333)}}
-		err = k8sClient.Create(ctx, svc2)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, svc2)).To(Succeed())
 
-		Eventually(func() string {
-			svc2 = &corev1.Service{}
-			if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: rootNS, Name: "svc2"}, svc2); err != nil {
-				return ""
-			}
-			//lint:ignore SA1019 subject for removal
-			return svc2.Annotations[constants.AnnGenerated]
-		}).Should(Equal(notGenerated))
+		//lint:ignore SA1019 subject for removal
+		Eventually(komega.Object(svc2)).Should(HaveField("Annotations", HaveKeyWithValue(constants.AnnGenerated, notGenerated)))
 	})
 })

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -79,43 +80,38 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+	komega.SetClient(k8sClient)
 
 	// prepare resources
 	ns := &corev1.Namespace{}
 	ns.Name = "prop-root"
 	ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-	err = k8sClient.Create(context.Background(), ns)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
 
 	ns = &corev1.Namespace{}
 	ns.Name = "prop-sub1"
 	ns.Labels = map[string]string{constants.LabelParent: "prop-root"}
-	err = k8sClient.Create(context.Background(), ns)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
 
 	ns = &corev1.Namespace{}
 	ns.Name = "prop-sub2"
 	ns.Labels = map[string]string{constants.LabelParent: "prop-root"}
-	err = k8sClient.Create(context.Background(), ns)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
 
 	ns = &corev1.Namespace{}
 	ns.Name = "prop-sub1-sub"
 	ns.Labels = map[string]string{constants.LabelParent: "prop-sub1"}
-	err = k8sClient.Create(context.Background(), ns)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
 
 	ns = &corev1.Namespace{}
 	ns.Name = "prop-tmpl"
 	ns.Labels = map[string]string{constants.LabelType: constants.NSTypeTemplate}
-	err = k8sClient.Create(context.Background(), ns)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
 
 	ns = &corev1.Namespace{}
 	ns.Name = "prop-instance"
 	ns.Labels = map[string]string{constants.LabelTemplate: "prop-tmpl"}
-	err = k8sClient.Create(context.Background(), ns)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
 
 })
 

--- a/hooks/namespace_test.go
+++ b/hooks/namespace_test.go
@@ -15,12 +15,11 @@ var _ = Describe("Namespace webhook", func() {
 	It("should allow creating a normal namespace", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "normal"
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		By("referencing a non-template as a template")
 		ns.Labels = map[string]string{constants.LabelTemplate: "default"}
-		err = k8sClient.Update(ctx, ns)
+		err := k8sClient.Update(ctx, ns)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -28,20 +27,18 @@ var _ = Describe("Namespace webhook", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "tmpl1"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeTemplate}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		instance := &corev1.Namespace{}
 		instance.Name = "instance-of-tmpl1"
 		instance.Labels = map[string]string{
 			constants.LabelTemplate: "tmpl1",
 		}
-		err = k8sClient.Create(ctx, instance)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, instance)).To(Succeed())
 
 		By("removing accurate.cybozu.com/type label from tmpl1")
 		ns.Labels = nil
-		err = k8sClient.Update(ctx, ns)
+		err := k8sClient.Update(ctx, ns)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -85,13 +82,12 @@ var _ = Describe("Namespace webhook", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "non-root-non-sub"
 		ns.Labels = map[string]string{constants.LabelType: "not-a-root"}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-non-root-non-sub"
 		sub.Labels = map[string]string{constants.LabelParent: "non-root-non-sub"}
-		err = k8sClient.Create(ctx, sub)
+		err := k8sClient.Create(ctx, sub)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -99,57 +95,49 @@ var _ = Describe("Namespace webhook", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "create-root"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-create-root"
 		sub.Labels = map[string]string{constants.LabelParent: "create-root"}
-		err = k8sClient.Create(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
 	})
 
 	It("should allow creating a sub-namespace under another sub-namespace", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "create-root2"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-create-root2"
 		sub.Labels = map[string]string{constants.LabelParent: "create-root2"}
-		err = k8sClient.Create(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
 
 		sub2 := &corev1.Namespace{}
 		sub2.Name = "sub2-of-create-root2"
 		sub2.Labels = map[string]string{constants.LabelParent: "sub-of-create-root2"}
-		err = k8sClient.Create(ctx, sub2)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub2)).To(Succeed())
 	})
 
 	It("should deny updating a sub-namespace that would create a circular reference", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "non-circular-root"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-non-circular-root"
 		sub.Labels = map[string]string{constants.LabelParent: "non-circular-root"}
-		err = k8sClient.Create(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
 
 		sub2 := &corev1.Namespace{}
 		sub2.Name = "sub2-of-non-circular-root"
 		sub2.Labels = map[string]string{constants.LabelParent: "sub-of-non-circular-root"}
-		err = k8sClient.Create(ctx, sub2)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub2)).To(Succeed())
 
 		sub.Labels[constants.LabelParent] = "sub2-of-non-circular-root"
-		err = k8sClient.Update(ctx, sub)
+		err := k8sClient.Update(ctx, sub)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -157,8 +145,7 @@ var _ = Describe("Namespace webhook", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "non-circular-root2"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeTemplate}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-non-circular-root2"
@@ -166,8 +153,7 @@ var _ = Describe("Namespace webhook", func() {
 			constants.LabelType:     constants.NSTypeTemplate,
 			constants.LabelTemplate: "non-circular-root2",
 		}
-		err = k8sClient.Create(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
 
 		sub2 := &corev1.Namespace{}
 		sub2.Name = "sub2-of-non-circular-root2"
@@ -175,11 +161,10 @@ var _ = Describe("Namespace webhook", func() {
 			constants.LabelType:     constants.NSTypeTemplate,
 			constants.LabelTemplate: "sub-of-non-circular-root2",
 		}
-		err = k8sClient.Create(ctx, sub2)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub2)).To(Succeed())
 
 		sub.Labels[constants.LabelTemplate] = "sub2-of-non-circular-root2"
-		err = k8sClient.Update(ctx, sub)
+		err := k8sClient.Update(ctx, sub)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -187,8 +172,7 @@ var _ = Describe("Namespace webhook", func() {
 		tmpl := &corev1.Namespace{}
 		tmpl.Name = "dusht-tmpl"
 		tmpl.Labels = map[string]string{constants.LabelType: constants.NSTypeTemplate}
-		err := k8sClient.Create(ctx, tmpl)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, tmpl)).To(Succeed())
 
 		ns := &corev1.Namespace{}
 		ns.Name = "template-root"
@@ -196,17 +180,15 @@ var _ = Describe("Namespace webhook", func() {
 			constants.LabelType:     constants.NSTypeRoot,
 			constants.LabelTemplate: "dusht-tmpl",
 		}
-		err = k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-template-root"
 		sub.Labels = map[string]string{constants.LabelParent: "template-root"}
-		err = k8sClient.Create(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
 
 		sub.Labels[constants.LabelTemplate] = "dusht-tmpl"
-		err = k8sClient.Update(ctx, sub)
+		err := k8sClient.Update(ctx, sub)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -214,17 +196,15 @@ var _ = Describe("Namespace webhook", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "root-of-sub-mark"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-root-of-sub-mark"
 		sub.Labels = map[string]string{constants.LabelParent: "root-of-sub-mark"}
-		err = k8sClient.Create(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
 
 		sub.Labels[constants.LabelType] = constants.NSTypeRoot
-		err = k8sClient.Update(ctx, sub)
+		err := k8sClient.Update(ctx, sub)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -232,23 +212,20 @@ var _ = Describe("Namespace webhook", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "root-after-non-root"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-root-after-non-root"
 		sub.Labels = map[string]string{constants.LabelParent: "root-after-non-root"}
-		err = k8sClient.Create(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
 
 		sub2 := &corev1.Namespace{}
 		sub2.Name = "sub2-of-root-after-non-root"
 		sub2.Labels = map[string]string{constants.LabelParent: "sub-of-root-after-non-root"}
-		err = k8sClient.Create(ctx, sub2)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub2)).To(Succeed())
 
 		delete(ns.Labels, constants.LabelType)
-		err = k8sClient.Update(ctx, ns)
+		err := k8sClient.Update(ctx, ns)
 		Expect(err).To(HaveOccurred())
 
 		delete(sub.Labels, constants.LabelParent)
@@ -260,29 +237,25 @@ var _ = Describe("Namespace webhook", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "root-after-non-root3"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		ns.Labels = nil
-		err = k8sClient.Update(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Update(ctx, ns)).To(Succeed())
 	})
 
 	It("should deny updating a template namespace having one or more instances that would become a non-template", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "tmpl-to-non-tmpl"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeTemplate}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		child := &corev1.Namespace{}
 		child.Name = "child-of-tmpl-to-non-tmpl"
 		child.Labels = map[string]string{constants.LabelTemplate: "tmpl-to-non-tmpl"}
-		err = k8sClient.Create(ctx, child)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, child)).To(Succeed())
 
 		delete(ns.Labels, constants.LabelType)
-		err = k8sClient.Update(ctx, ns)
+		err := k8sClient.Update(ctx, ns)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -290,71 +263,60 @@ var _ = Describe("Namespace webhook", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "tmpl-to-non-tmpl2"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeTemplate}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		delete(ns.Labels, constants.LabelType)
-		err = k8sClient.Update(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Update(ctx, ns)).To(Succeed())
 	})
 
 	It("should allow turning a sub-namespace w/o children into a normal namespace", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "root-of-depth1"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-root-of-depth1"
 		sub.Labels = map[string]string{constants.LabelParent: "root-of-depth1"}
-		err = k8sClient.Create(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
 
 		sub.Labels = nil
-		err = k8sClient.Update(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Update(ctx, sub)).To(Succeed())
 	})
 
 	It("should allow turning a sub-namespace w/ children into a root namespace", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "root-for-sub-to-root"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-root-for-sub-to-root"
 		sub.Labels = map[string]string{constants.LabelParent: "root-for-sub-to-root"}
-		err = k8sClient.Create(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
 
 		sub2 := &corev1.Namespace{}
 		sub2.Name = "sub2-of-root-for-sub-to-root"
 		sub2.Labels = map[string]string{constants.LabelParent: "sub-of-root-for-sub-to-root"}
-		err = k8sClient.Create(ctx, sub2)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub2)).To(Succeed())
 
 		sub.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err = k8sClient.Update(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Update(ctx, sub)).To(Succeed())
 	})
 
 	It("should deny changing a sub-namespace into a dangling sub-namespace", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "dangling-root"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-dangling-root"
 		sub.Labels = map[string]string{constants.LabelParent: "dangling-root"}
-		err = k8sClient.Create(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
 
 		sub.Labels[constants.LabelParent] = "none"
-		err = k8sClient.Update(ctx, sub)
+		err := k8sClient.Update(ctx, sub)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -362,17 +324,15 @@ var _ = Describe("Namespace webhook", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "dangling-root2"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeTemplate}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-dangling-root2"
 		sub.Labels = map[string]string{constants.LabelTemplate: "dangling-root2"}
-		err = k8sClient.Create(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
 
 		sub.Labels[constants.LabelTemplate] = "none"
-		err = k8sClient.Update(ctx, sub)
+		err := k8sClient.Update(ctx, sub)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -380,22 +340,19 @@ var _ = Describe("Namespace webhook", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "move-root"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-move-root"
 		sub.Labels = map[string]string{constants.LabelParent: "move-root"}
-		err = k8sClient.Create(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
 
 		nonRoot := &corev1.Namespace{}
 		nonRoot.Name = "move-non-root-non-sub"
-		err = k8sClient.Create(ctx, nonRoot)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, nonRoot)).To(Succeed())
 
 		sub.Labels[constants.LabelParent] = "move-non-root-non-sub"
-		err = k8sClient.Update(ctx, sub)
+		err := k8sClient.Update(ctx, sub)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -403,18 +360,16 @@ var _ = Describe("Namespace webhook", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "delete-root"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-delete-root"
 		sub.Labels = map[string]string{constants.LabelParent: "delete-root"}
-		err = k8sClient.Create(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
 
 		ns = &corev1.Namespace{}
 		ns.Name = "delete-root"
-		err = k8sClient.Delete(ctx, ns)
+		err := k8sClient.Delete(ctx, ns)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -422,24 +377,21 @@ var _ = Describe("Namespace webhook", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "delete-root2"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-delete-root2"
 		sub.Labels = map[string]string{constants.LabelParent: "delete-root2"}
-		err = k8sClient.Create(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
 
 		sub2 := &corev1.Namespace{}
 		sub2.Name = "sub2-of-delete-root2"
 		sub2.Labels = map[string]string{constants.LabelParent: "sub-of-delete-root2"}
-		err = k8sClient.Create(ctx, sub2)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub2)).To(Succeed())
 
 		sub = &corev1.Namespace{}
 		sub.Name = "sub-of-delete-root2"
-		err = k8sClient.Delete(ctx, sub)
+		err := k8sClient.Delete(ctx, sub)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -447,16 +399,14 @@ var _ = Describe("Namespace webhook", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "delete-tmpl1"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeTemplate}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-delete-tmpl1"
 		sub.Labels = map[string]string{constants.LabelTemplate: "delete-tmpl1"}
-		err = k8sClient.Create(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
 
-		err = k8sClient.Delete(ctx, ns)
+		err := k8sClient.Delete(ctx, ns)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -464,56 +414,47 @@ var _ = Describe("Namespace webhook", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "delete-root3"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-delete-root3"
 		sub.Labels = map[string]string{constants.LabelParent: "delete-root3"}
-		err = k8sClient.Create(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
 
 		sub = &corev1.Namespace{}
 		sub.Name = "sub-of-delete-root3"
-		err = k8sClient.Delete(ctx, sub)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Delete(ctx, sub)).To(Succeed())
 	})
 
 	It("should allow deleting a root namespace w/o children", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "delete-root4"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		ns = &corev1.Namespace{}
 		ns.Name = "delete-root4"
-		err = k8sClient.Delete(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
 	})
 
 	It("should allow deleting a non-root and non-sub namespace", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "delete-root5"
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		ns = &corev1.Namespace{}
 		ns.Name = "delete-root5"
-		err = k8sClient.Delete(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
 	})
 
 	It("should allow deleting a template namespace w/o instances", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "delete-tmpl2"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeTemplate}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		ns = &corev1.Namespace{}
 		ns.Name = "delete-tmpl2"
-		err = k8sClient.Delete(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
 	})
 })

--- a/hooks/subnamespace_test.go
+++ b/hooks/subnamespace_test.go
@@ -21,13 +21,12 @@ var _ = Describe("SubNamespace webhook", func() {
 	It("should deny creation of SubNamespace in a namespace that is neither root nor subnamespace", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "ns1"
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sn := &accuratev1.SubNamespace{}
 		sn.Namespace = "ns1"
 		sn.Name = "foo"
-		err = k8sClient.Create(ctx, sn)
+		err := k8sClient.Create(ctx, sn)
 		Expect(err).To(HaveOccurred())
 		Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 	})
@@ -36,27 +35,23 @@ var _ = Describe("SubNamespace webhook", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "ns2"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sn := &accuratev1.SubNamespace{}
 		sn.Namespace = "ns2"
 		sn.Name = "foo"
 		sn.Spec.Labels = map[string]string{"foo": "bar"}
 		sn.Spec.Annotations = map[string]string{"foo": "bar"}
-		err = k8sClient.Create(ctx, sn)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sn)).To(Succeed())
 
 		Expect(controllerutil.ContainsFinalizer(sn, constants.Finalizer)).To(BeTrue())
 
 		// deleting finalizer should succeed
 		sn.Finalizers = nil
-		err = k8sClient.Update(ctx, sn)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Update(ctx, sn)).To(Succeed())
 
 		sn = &accuratev1.SubNamespace{}
-		err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "ns2", Name: "foo"}, sn)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: "ns2", Name: "foo"}, sn)).To(Succeed())
 		Expect(sn.Finalizers).To(BeEmpty())
 	})
 
@@ -64,20 +59,17 @@ var _ = Describe("SubNamespace webhook", func() {
 		nsP := &corev1.Namespace{}
 		nsP.Name = "ns-parent"
 		nsP.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err := k8sClient.Create(ctx, nsP)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, nsP)).To(Succeed())
 
 		ns := &corev1.Namespace{}
 		ns.Name = "ns3"
 		ns.Labels = map[string]string{constants.LabelParent: "ns-parent"}
-		err = k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sn := &accuratev1.SubNamespace{}
 		sn.Namespace = "ns3"
 		sn.Name = "bar"
-		err = k8sClient.Create(ctx, sn)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sn)).To(Succeed())
 
 		Expect(controllerutil.ContainsFinalizer(sn, constants.Finalizer)).To(BeTrue())
 	})
@@ -89,90 +81,77 @@ var _ = Describe("SubNamespace webhook", func() {
 					ns := &corev1.Namespace{}
 					ns.Name = "naming-policy-root-1"
 					ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-					err := k8sClient.Create(ctx, ns)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 					sn := &accuratev1.SubNamespace{}
 					sn.Namespace = "naming-policy-root-1"
 					sn.Name = "naming-policy-root-1-child"
-					err = k8sClient.Create(ctx, sn)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, sn)).To(Succeed())
 				})
 
 				It("should allow creation of SubNamespace in a root namespace - pattern2", func() {
 					ns := &corev1.Namespace{}
 					ns.Name = "root-ns-match-1"
 					ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-					err := k8sClient.Create(ctx, ns)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 					sn := &accuratev1.SubNamespace{}
 					sn.Namespace = "root-ns-match-1"
 					sn.Name = "child-match-1"
-					err = k8sClient.Create(ctx, sn)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, sn)).To(Succeed())
 				})
 
 				It("should allow creation of SubNamespace in a root namespace - pattern3", func() {
 					root := &corev1.Namespace{}
 					root.Name = "ns-root-1"
 					root.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-					err := k8sClient.Create(ctx, root)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, root)).To(Succeed())
 
 					parent := &corev1.Namespace{}
 					parent.Name = "ns-root-1-parent"
 					parent.Labels = map[string]string{constants.LabelParent: "ns-root-1"}
-					err = k8sClient.Create(ctx, parent)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, parent)).To(Succeed())
 
 					sn := &accuratev1.SubNamespace{}
 					sn.Namespace = "ns-root-1-parent"
 					sn.Name = "ns-root-1-parent-child"
-					err = k8sClient.Create(ctx, sn)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, sn)).To(Succeed())
 				})
 
 				It("should allow creation of SubNamespace in a root namespace - pattern4", func() {
 					root := &corev1.Namespace{}
 					root.Name = "app-team1"
 					root.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-					err := k8sClient.Create(ctx, root)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, root)).To(Succeed())
 
 					sn := &accuratev1.SubNamespace{}
 					sn.Namespace = "app-team1"
 					sn.Name = "app-team1-child"
-					err = k8sClient.Create(ctx, sn)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, sn)).To(Succeed())
 				})
 
 				It("should allow creation of SubNamespace in a root namespace - pattern5", func() {
 					root := &corev1.Namespace{}
 					root.Name = "app-team2-app1"
 					root.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-					err := k8sClient.Create(ctx, root)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, root)).To(Succeed())
 
 					sn := &accuratev1.SubNamespace{}
 					sn.Namespace = "app-team2-app1"
 					sn.Name = "app-team2-app1-subapp1"
-					err = k8sClient.Create(ctx, sn)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, sn)).To(Succeed())
 				})
 
 				It("should allow creation of SubNamespace in a root namespace - pattern6", func() {
 					root := &corev1.Namespace{}
 					root.Name = "unuse-naming-group-team1"
 					root.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-					err := k8sClient.Create(ctx, root)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, root)).To(Succeed())
 
 					sn := &accuratev1.SubNamespace{}
 					sn.Namespace = "unuse-naming-group-team1"
 					sn.Name = "unuse-naming-group-child1"
-					err = k8sClient.Create(ctx, sn)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, sn)).To(Succeed())
 				})
 			})
 
@@ -181,13 +160,12 @@ var _ = Describe("SubNamespace webhook", func() {
 					ns := &corev1.Namespace{}
 					ns.Name = "naming-policy-root-2"
 					ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-					err := k8sClient.Create(ctx, ns)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 					sn := &accuratev1.SubNamespace{}
 					sn.Namespace = "naming-policy-root-2"
 					sn.Name = "naming-policy-root-2--child"
-					err = k8sClient.Create(ctx, sn)
+					err := k8sClient.Create(ctx, sn)
 					Expect(err).To(HaveOccurred())
 					Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 				})
@@ -196,13 +174,12 @@ var _ = Describe("SubNamespace webhook", func() {
 					ns := &corev1.Namespace{}
 					ns.Name = "root-ns-match-2"
 					ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-					err := k8sClient.Create(ctx, ns)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 					sn := &accuratev1.SubNamespace{}
 					sn.Namespace = "root-ns-match-2"
 					sn.Name = "child-2"
-					err = k8sClient.Create(ctx, sn)
+					err := k8sClient.Create(ctx, sn)
 					Expect(err).To(HaveOccurred())
 					Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 				})
@@ -211,19 +188,17 @@ var _ = Describe("SubNamespace webhook", func() {
 					root := &corev1.Namespace{}
 					root.Name = "ns-root-2"
 					root.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-					err := k8sClient.Create(ctx, root)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, root)).To(Succeed())
 
 					parent := &corev1.Namespace{}
 					parent.Name = "ns-root-2-parent"
 					parent.Labels = map[string]string{constants.LabelParent: "ns-root-1"}
-					err = k8sClient.Create(ctx, parent)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, parent)).To(Succeed())
 
 					sn := &accuratev1.SubNamespace{}
 					sn.Namespace = "ns-root-2-parent"
 					sn.Name = "not-ns-root-2-parent-child"
-					err = k8sClient.Create(ctx, sn)
+					err := k8sClient.Create(ctx, sn)
 					Expect(err).To(HaveOccurred())
 					Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 				})
@@ -232,13 +207,12 @@ var _ = Describe("SubNamespace webhook", func() {
 					root := &corev1.Namespace{}
 					root.Name = "app-team10"
 					root.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-					err := k8sClient.Create(ctx, root)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, root)).To(Succeed())
 
 					sn := &accuratev1.SubNamespace{}
 					sn.Namespace = "app-team10"
 					sn.Name = "app-team20-child"
-					err = k8sClient.Create(ctx, sn)
+					err := k8sClient.Create(ctx, sn)
 					Expect(err).To(HaveOccurred())
 					Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 				})
@@ -247,13 +221,12 @@ var _ = Describe("SubNamespace webhook", func() {
 					root := &corev1.Namespace{}
 					root.Name = "unuse-naming-group-team2"
 					root.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-					err := k8sClient.Create(ctx, root)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, root)).To(Succeed())
 
 					sn := &accuratev1.SubNamespace{}
 					sn.Namespace = "unuse-naming-group-team2"
 					sn.Name = "unuse-naming-group-team2-foo"
-					err = k8sClient.Create(ctx, sn)
+					err := k8sClient.Create(ctx, sn)
 					Expect(err).To(HaveOccurred())
 					Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 				})
@@ -262,14 +235,13 @@ var _ = Describe("SubNamespace webhook", func() {
 					root := &corev1.Namespace{}
 					root.Name = "labels-invalid-1"
 					root.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-					err := k8sClient.Create(ctx, root)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, root)).To(Succeed())
 
 					sn := &accuratev1.SubNamespace{}
 					sn.Namespace = "labels-invalid-1"
 					sn.Name = "labels-invalid-1-sub"
 					sn.Spec.Labels = map[string]string{"foo": "~"}
-					err = k8sClient.Create(ctx, sn)
+					err := k8sClient.Create(ctx, sn)
 					Expect(err).To(HaveOccurred())
 					Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 				})
@@ -278,14 +250,13 @@ var _ = Describe("SubNamespace webhook", func() {
 					root := &corev1.Namespace{}
 					root.Name = "annotations-invalid-1"
 					root.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-					err := k8sClient.Create(ctx, root)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, root)).To(Succeed())
 
 					sn := &accuratev1.SubNamespace{}
 					sn.Namespace = "annotations-invalid-1"
 					sn.Name = "annotations-invalid-1-sub"
 					sn.Spec.Annotations = map[string]string{"foo-": ""}
-					err = k8sClient.Create(ctx, sn)
+					err := k8sClient.Create(ctx, sn)
 					Expect(err).To(HaveOccurred())
 					Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 				})
@@ -294,15 +265,14 @@ var _ = Describe("SubNamespace webhook", func() {
 					root := &corev1.Namespace{}
 					root.Name = "both-invalid-1"
 					root.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-					err := k8sClient.Create(ctx, root)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(k8sClient.Create(ctx, root)).To(Succeed())
 
 					sn := &accuratev1.SubNamespace{}
 					sn.Namespace = "both-invalid-1"
 					sn.Name = "both-invalid-1-sub"
 					sn.Spec.Labels = map[string]string{"foo": "~"}
 					sn.Spec.Annotations = map[string]string{"foo-": ""}
-					err = k8sClient.Create(ctx, sn)
+					err := k8sClient.Create(ctx, sn)
 					Expect(err).To(HaveOccurred())
 					Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 				})

--- a/hooks/subnamespace_v2_test.go
+++ b/hooks/subnamespace_v2_test.go
@@ -22,13 +22,12 @@ var _ = Describe("SubNamespace webhook", func() {
 	It("should deny creation of v2 SubNamespace in a namespace that is neither root nor subnamespace", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "v2alpha1-ns1"
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sn := &accuratev2alpha1.SubNamespace{}
 		sn.Namespace = "v2alpha1-ns1"
 		sn.Name = "v2alpha1-foo"
-		err = k8sClient.Create(ctx, sn)
+		err := k8sClient.Create(ctx, sn)
 		Expect(err).To(HaveOccurred())
 		Expect(errors.ReasonForError(err)).Should(Equal(metav1.StatusReasonForbidden))
 	})
@@ -37,27 +36,23 @@ var _ = Describe("SubNamespace webhook", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "v2alpha1-ns2"
 		ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).To(Succeed())
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		sn := &accuratev2alpha1.SubNamespace{}
 		sn.Namespace = "v2alpha1-ns2"
 		sn.Name = "v2alpha1-foo"
 		sn.Spec.Labels = map[string]string{"foo": "bar"}
 		sn.Spec.Annotations = map[string]string{"foo": "bar"}
-		err = k8sClient.Create(ctx, sn)
-		Expect(err).To(Succeed())
+		Expect(k8sClient.Create(ctx, sn)).To(Succeed())
 
 		Expect(controllerutil.ContainsFinalizer(sn, constants.Finalizer)).To(BeTrue())
 
 		// deleting finalizer should succeed
 		sn.Finalizers = nil
-		err = k8sClient.Update(ctx, sn)
-		Expect(err).To(Succeed())
+		Expect(k8sClient.Update(ctx, sn)).To(Succeed())
 
 		sn = &accuratev2alpha1.SubNamespace{}
-		err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "v2alpha1-ns2", Name: "v2alpha1-foo"}, sn)
-		Expect(err).To(Succeed())
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: "v2alpha1-ns2", Name: "v2alpha1-foo"}, sn)).To(Succeed())
 		Expect(sn.Finalizers).To(BeEmpty())
 	})
 


### PR DESCRIPTION
This introduces [komega](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.16.3/pkg/envtest/komega) from controller-runtime envtest framework. IMO it makes the test more readable and test-code shorter. Also standardizing on the Ginkgo pattern to use `Expect(<func>).Should(Succeed())` when the K8s client operation is supposed to success without error. It just makes things a bit more compact.

I hope you like this, and that the PR is reviewable. It is a bit large in the number of changes, but I have attempted to change things in a way that doesn't clutter the diff.

This PR is mainly motivated by planned test improvements in https://github.com/cybozu-go/accurate/pull/112.