### PR TITLE
build(deps): bump Kubernetes to 1.29

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,9 +36,9 @@ jobs:
     strategy:
       matrix:
         k8s-version:
-        - v1.26.6 # renovate: kindest/node
-        - v1.27.3 # renovate: kindest/node
-        - v1.28.0 # renovate: kindest/node
+        - v1.27.10 # renovate: kindest/node
+        - v1.28.6 # renovate: kindest/node
+        - v1.29.1 # renovate: kindest/node
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -7,7 +7,7 @@ registries:
     type: local
     path: registry.yaml
 packages:
-  - name: kubernetes/kubectl@v1.28.2
+  - name: kubernetes/kubectl@v1.29.1
   - name: kubernetes-sigs/kubebuilder@v3.11.0
   - name: kubernetes-sigs/kustomize@kustomize/v5.1.0
   - name: kubernetes-sigs/kind@v0.20.0

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,4 +1,4 @@
-KUBERNETES_VERSION = v1.28.0 # renovate: kindest/node
+KUBERNETES_VERSION = v1.29.1 # renovate: kindest/node
 
 KUBECTL_ACCURATE := $(dir $(shell pwd))/bin/kubectl-accurate
 KUBECONFIG := $(shell pwd)/.kubeconfig


### PR DESCRIPTION
This bumps the supported Kubernetes to 1.29 as documented in https://cybozu-go.github.io/accurate/maintenance.html. The Go dependencies are bumped in https://github.com/cybozu-go/accurate/pull/117.

It seems like Renovate is no longer operating on this project, so I bumped the patch versions of the supported K8s releases also.