### PR TITLE
fix: upgrade managed fields in controller resources from CSA to SSA

### DIFF
--- a/controllers/propagate.go
+++ b/controllers/propagate.go
@@ -269,6 +269,13 @@ func (r *PropagateController) propagateUpdate(ctx context.Context, obj, parent *
 
 	if parent != nil {
 		clone := cloneResource(parent, obj.GetNamespace())
+
+		// Ensure that managed fields are upgraded to SSA before the following SSA.
+		// TODO(migration): This code could be removed after a couple of releases.
+		if err := upgradeManagedFields(ctx, r.Client, clone); err != nil {
+			return err
+		}
+
 		if !equality.Semantic.DeepDerivative(clone, obj) {
 			if err := r.Patch(ctx, clone, applyPatch{clone}, fieldOwner, client.ForceOwnership); err != nil {
 				return fmt.Errorf("failed to apply %s/%s: %w", clone.GetNamespace(), clone.GetName(), err)
@@ -302,6 +309,13 @@ func (r *PropagateController) propagateUpdate(ctx context.Context, obj, parent *
 		}
 
 		clone := cloneResource(obj, child.Name)
+
+		// Ensure that managed fields are upgraded to SSA before the following SSA.
+		// TODO(migration): This code could be removed after a couple of releases.
+		if err := upgradeManagedFields(ctx, r.Client, clone); err != nil {
+			return err
+		}
+
 		if equality.Semantic.DeepDerivative(clone, cres) {
 			continue
 		}

--- a/controllers/ssa_client.go
+++ b/controllers/ssa_client.go
@@ -1,19 +1,39 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 
 	accuratev2alpha1 "github.com/cybozu-go/accurate/api/accurate/v2alpha1"
 	accuratev2alpha1ac "github.com/cybozu-go/accurate/internal/applyconfigurations/accurate/v2alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/client-go/util/csaupgrade"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
 	fieldOwner client.FieldOwner = "accurate-controller"
 )
+
+// TODO(migration): This code could be removed after a couple of releases.
+// upgradeManagedFields is a migration function that migrates the ownership of
+// fields from the Update operation to the Apply operation. This is required
+// to ensure that the apply operations will also remove fields that were
+// set by the Update operation.
+func upgradeManagedFields(ctx context.Context, c client.Client, obj client.Object) error {
+	patch, err := csaupgrade.UpgradeManagedFieldsPatch(obj, sets.New(string(fieldOwner)), string(fieldOwner))
+	if err != nil {
+		return err
+	}
+	if patch != nil {
+		return c.Patch(ctx, obj, client.RawPatch(types.JSONPatchType, patch))
+	}
+	// No work to be done - already upgraded
+	return nil
+}
 
 func newSubNamespacePatch(ac *accuratev2alpha1ac.SubNamespaceApplyConfiguration) (*accuratev2alpha1.SubNamespace, client.Patch, error) {
 	sn := &accuratev2alpha1.SubNamespace{}

--- a/controllers/subnamespace_controller.go
+++ b/controllers/subnamespace_controller.go
@@ -136,6 +136,8 @@ func (r *SubNamespaceReconciler) reconcileNS(ctx context.Context, sn *accuratev2
 		)
 	}
 
+	// TODO: upgrade managed fields to SSA when https://github.com/kubernetes/kubernetes/pull/123484 is released
+
 	sn, p, err := newSubNamespacePatch(ac)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR reuses the upstream code that `kubectl` uses to upgrade `managedFields` from CSA to SSA. It appears like subresources are not supported yet, but I am working on it in https://github.com/kubernetes/kubernetes/pull/123484. The PR allowing us to upgrade managed fields for subresources is now merged and should be released with the upcoming K8s 1.30. I will create a follow-up PR when the improved helper is available, but this PR fixes the main issue.

Fixes https://github.com/cybozu-go/accurate/issues/120