### PR TITLE
test: improve namespace webhook tests

### DIFF
--- a/hooks/namespace_test.go
+++ b/hooks/namespace_test.go
@@ -19,8 +19,7 @@ var _ = Describe("Namespace webhook", func() {
 
 		By("referencing a non-template as a template")
 		ns.Labels = map[string]string{constants.LabelTemplate: "default"}
-		err := k8sClient.Update(ctx, ns)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Update(ctx, ns)).To(MatchError(ContainSubstring("default is not a valid template namespace")))
 	})
 
 	It("should allow referencing a template namespace", func() {
@@ -34,12 +33,11 @@ var _ = Describe("Namespace webhook", func() {
 		instance.Labels = map[string]string{
 			constants.LabelTemplate: "tmpl1",
 		}
-		Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, instance)).Should(Succeed())
 
 		By("removing accurate.cybozu.com/type label from tmpl1")
 		ns.Labels = nil
-		err := k8sClient.Update(ctx, ns)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Update(ctx, ns)).To(MatchError(ContainSubstring("there are namespaces referencing tmpl1")))
 	})
 
 	It("should deny creating a self-referencing namespace", func() {
@@ -48,15 +46,13 @@ var _ = Describe("Namespace webhook", func() {
 		ns.Labels = map[string]string{
 			constants.LabelParent: "self-reference",
 		}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(MatchError(ContainSubstring("circular reference is not permitted")))
 
 		ns.Labels = map[string]string{
 			constants.LabelType:     constants.NSTypeTemplate,
 			constants.LabelTemplate: "self-reference",
 		}
-		err = k8sClient.Create(ctx, ns)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(MatchError(ContainSubstring("circular reference is not permitted")))
 	})
 
 	It("should deny creating a sub-namespace having a template", func() {
@@ -66,16 +62,14 @@ var _ = Describe("Namespace webhook", func() {
 			constants.LabelParent:   "kube-system",
 			constants.LabelTemplate: "default",
 		}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(MatchError(ContainSubstring("a sub-namespace cannot have a template")))
 	})
 
 	It("should deny creating a dangling sub-namespace", func() {
 		ns := &corev1.Namespace{}
 		ns.Name = "create-dangling"
 		ns.Labels = map[string]string{constants.LabelParent: "notexist"}
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Create(ctx, ns)).To(MatchError(ContainSubstring("namespace does not exist: notexist")))
 	})
 
 	It("should deny creating a sub-namespace under non-root/non-sub namespace", func() {
@@ -87,8 +81,7 @@ var _ = Describe("Namespace webhook", func() {
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-non-root-non-sub"
 		sub.Labels = map[string]string{constants.LabelParent: "non-root-non-sub"}
-		err := k8sClient.Create(ctx, sub)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Create(ctx, sub)).To(MatchError(ContainSubstring("non-root-non-sub is not a valid root namespace")))
 	})
 
 	It("should allow creating a sub-namespace under a root namespace", func() {
@@ -100,7 +93,7 @@ var _ = Describe("Namespace webhook", func() {
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-create-root"
 		sub.Labels = map[string]string{constants.LabelParent: "create-root"}
-		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub)).Should(Succeed())
 	})
 
 	It("should allow creating a sub-namespace under another sub-namespace", func() {
@@ -112,12 +105,12 @@ var _ = Describe("Namespace webhook", func() {
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-create-root2"
 		sub.Labels = map[string]string{constants.LabelParent: "create-root2"}
-		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub)).Should(Succeed())
 
 		sub2 := &corev1.Namespace{}
 		sub2.Name = "sub2-of-create-root2"
 		sub2.Labels = map[string]string{constants.LabelParent: "sub-of-create-root2"}
-		Expect(k8sClient.Create(ctx, sub2)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub2)).Should(Succeed())
 	})
 
 	It("should deny updating a sub-namespace that would create a circular reference", func() {
@@ -129,16 +122,15 @@ var _ = Describe("Namespace webhook", func() {
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-non-circular-root"
 		sub.Labels = map[string]string{constants.LabelParent: "non-circular-root"}
-		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub)).Should(Succeed())
 
 		sub2 := &corev1.Namespace{}
 		sub2.Name = "sub2-of-non-circular-root"
 		sub2.Labels = map[string]string{constants.LabelParent: "sub-of-non-circular-root"}
-		Expect(k8sClient.Create(ctx, sub2)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub2)).Should(Succeed())
 
 		sub.Labels[constants.LabelParent] = "sub2-of-non-circular-root"
-		err := k8sClient.Update(ctx, sub)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Update(ctx, sub)).To(MatchError(ContainSubstring("circular reference is not permitted")))
 	})
 
 	It("should deny updating a template namespace that would create a circular reference", func() {
@@ -153,7 +145,7 @@ var _ = Describe("Namespace webhook", func() {
 			constants.LabelType:     constants.NSTypeTemplate,
 			constants.LabelTemplate: "non-circular-root2",
 		}
-		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub)).Should(Succeed())
 
 		sub2 := &corev1.Namespace{}
 		sub2.Name = "sub2-of-non-circular-root2"
@@ -161,11 +153,10 @@ var _ = Describe("Namespace webhook", func() {
 			constants.LabelType:     constants.NSTypeTemplate,
 			constants.LabelTemplate: "sub-of-non-circular-root2",
 		}
-		Expect(k8sClient.Create(ctx, sub2)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub2)).Should(Succeed())
 
 		sub.Labels[constants.LabelTemplate] = "sub2-of-non-circular-root2"
-		err := k8sClient.Update(ctx, sub)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Update(ctx, sub)).To(MatchError(ContainSubstring("circular reference is not permitted")))
 	})
 
 	It("should deny updating a sub-namespace to have a template", func() {
@@ -180,16 +171,15 @@ var _ = Describe("Namespace webhook", func() {
 			constants.LabelType:     constants.NSTypeRoot,
 			constants.LabelTemplate: "dusht-tmpl",
 		}
-		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, ns)).Should(Succeed())
 
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-template-root"
 		sub.Labels = map[string]string{constants.LabelParent: "template-root"}
-		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub)).Should(Succeed())
 
 		sub.Labels[constants.LabelTemplate] = "dusht-tmpl"
-		err := k8sClient.Update(ctx, sub)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Update(ctx, sub)).To(MatchError(ContainSubstring("a sub-namespace cannot have a template")))
 	})
 
 	It("should deny marking a sub-namespace as a root namespace", func() {
@@ -201,11 +191,10 @@ var _ = Describe("Namespace webhook", func() {
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-root-of-sub-mark"
 		sub.Labels = map[string]string{constants.LabelParent: "root-of-sub-mark"}
-		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub)).Should(Succeed())
 
 		sub.Labels[constants.LabelType] = constants.NSTypeRoot
-		err := k8sClient.Update(ctx, sub)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Update(ctx, sub)).To(MatchError(ContainSubstring("a sub-namespace cannot be a root or a template")))
 	})
 
 	It("should deny updating a namespace having children that would become a non-root and non-sub namespace", func() {
@@ -217,20 +206,18 @@ var _ = Describe("Namespace webhook", func() {
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-root-after-non-root"
 		sub.Labels = map[string]string{constants.LabelParent: "root-after-non-root"}
-		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub)).Should(Succeed())
 
 		sub2 := &corev1.Namespace{}
 		sub2.Name = "sub2-of-root-after-non-root"
 		sub2.Labels = map[string]string{constants.LabelParent: "sub-of-root-after-non-root"}
-		Expect(k8sClient.Create(ctx, sub2)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub2)).Should(Succeed())
 
 		delete(ns.Labels, constants.LabelType)
-		err := k8sClient.Update(ctx, ns)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Update(ctx, ns)).To(MatchError(ContainSubstring("there are sub-namespaces under root-after-non-root")))
 
 		delete(sub.Labels, constants.LabelParent)
-		err = k8sClient.Update(ctx, sub)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Update(ctx, sub)).To(MatchError(ContainSubstring("there are sub-namespaces under sub-of-root-after-non-root")))
 	})
 
 	It("should allow turning a root namespace into non-root if it has no children", func() {
@@ -252,11 +239,10 @@ var _ = Describe("Namespace webhook", func() {
 		child := &corev1.Namespace{}
 		child.Name = "child-of-tmpl-to-non-tmpl"
 		child.Labels = map[string]string{constants.LabelTemplate: "tmpl-to-non-tmpl"}
-		Expect(k8sClient.Create(ctx, child)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, child)).Should(Succeed())
 
 		delete(ns.Labels, constants.LabelType)
-		err := k8sClient.Update(ctx, ns)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Update(ctx, ns)).To(MatchError(ContainSubstring("there are namespaces referencing tmpl-to-non-tmpl")))
 	})
 
 	It("should allow turning a template w/o children namespace into a normal namespace", func() {
@@ -278,7 +264,7 @@ var _ = Describe("Namespace webhook", func() {
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-root-of-depth1"
 		sub.Labels = map[string]string{constants.LabelParent: "root-of-depth1"}
-		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub)).Should(Succeed())
 
 		sub.Labels = nil
 		Expect(k8sClient.Update(ctx, sub)).To(Succeed())
@@ -293,12 +279,12 @@ var _ = Describe("Namespace webhook", func() {
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-root-for-sub-to-root"
 		sub.Labels = map[string]string{constants.LabelParent: "root-for-sub-to-root"}
-		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub)).Should(Succeed())
 
 		sub2 := &corev1.Namespace{}
 		sub2.Name = "sub2-of-root-for-sub-to-root"
 		sub2.Labels = map[string]string{constants.LabelParent: "sub-of-root-for-sub-to-root"}
-		Expect(k8sClient.Create(ctx, sub2)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub2)).Should(Succeed())
 
 		sub.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
 		Expect(k8sClient.Update(ctx, sub)).To(Succeed())
@@ -313,11 +299,10 @@ var _ = Describe("Namespace webhook", func() {
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-dangling-root"
 		sub.Labels = map[string]string{constants.LabelParent: "dangling-root"}
-		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub)).Should(Succeed())
 
 		sub.Labels[constants.LabelParent] = "none"
-		err := k8sClient.Update(ctx, sub)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Update(ctx, sub)).To(MatchError(ContainSubstring("parent namespace does not exist: none")))
 	})
 
 	It("should deny changing an instance namespace into a dangling namespace", func() {
@@ -329,11 +314,10 @@ var _ = Describe("Namespace webhook", func() {
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-dangling-root2"
 		sub.Labels = map[string]string{constants.LabelTemplate: "dangling-root2"}
-		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub)).Should(Succeed())
 
 		sub.Labels[constants.LabelTemplate] = "none"
-		err := k8sClient.Update(ctx, sub)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Update(ctx, sub)).To(MatchError(ContainSubstring("parent namespace does not exist: none")))
 	})
 
 	It("should deny moving a sub-namespace under non-root/non-sub namespace", func() {
@@ -345,15 +329,14 @@ var _ = Describe("Namespace webhook", func() {
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-move-root"
 		sub.Labels = map[string]string{constants.LabelParent: "move-root"}
-		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub)).Should(Succeed())
 
 		nonRoot := &corev1.Namespace{}
 		nonRoot.Name = "move-non-root-non-sub"
 		Expect(k8sClient.Create(ctx, nonRoot)).To(Succeed())
 
 		sub.Labels[constants.LabelParent] = "move-non-root-non-sub"
-		err := k8sClient.Update(ctx, sub)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Update(ctx, sub)).To(MatchError(ContainSubstring("move-non-root-non-sub is not a valid root namespace")))
 	})
 
 	It("should deny deleting a root namespace w/ children", func() {
@@ -365,12 +348,11 @@ var _ = Describe("Namespace webhook", func() {
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-delete-root"
 		sub.Labels = map[string]string{constants.LabelParent: "delete-root"}
-		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub)).Should(Succeed())
 
 		ns = &corev1.Namespace{}
 		ns.Name = "delete-root"
-		err := k8sClient.Delete(ctx, ns)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Delete(ctx, ns)).To(MatchError(ContainSubstring("child namespaces exist")))
 	})
 
 	It("should deny deleting a sub-namespace w/ children", func() {
@@ -382,17 +364,16 @@ var _ = Describe("Namespace webhook", func() {
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-delete-root2"
 		sub.Labels = map[string]string{constants.LabelParent: "delete-root2"}
-		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub)).Should(Succeed())
 
 		sub2 := &corev1.Namespace{}
 		sub2.Name = "sub2-of-delete-root2"
 		sub2.Labels = map[string]string{constants.LabelParent: "sub-of-delete-root2"}
-		Expect(k8sClient.Create(ctx, sub2)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub2)).Should(Succeed())
 
 		sub = &corev1.Namespace{}
 		sub.Name = "sub-of-delete-root2"
-		err := k8sClient.Delete(ctx, sub)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Delete(ctx, sub)).To(MatchError(ContainSubstring("child namespaces exist")))
 	})
 
 	It("should deny deleting a template w/ children", func() {
@@ -404,10 +385,9 @@ var _ = Describe("Namespace webhook", func() {
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-delete-tmpl1"
 		sub.Labels = map[string]string{constants.LabelTemplate: "delete-tmpl1"}
-		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub)).Should(Succeed())
 
-		err := k8sClient.Delete(ctx, ns)
-		Expect(err).To(HaveOccurred())
+		Expect(k8sClient.Delete(ctx, ns)).To(MatchError(ContainSubstring("child namespaces exist")))
 	})
 
 	It("should allow deleting a sub-namespace w/o children", func() {
@@ -419,7 +399,7 @@ var _ = Describe("Namespace webhook", func() {
 		sub := &corev1.Namespace{}
 		sub.Name = "sub-of-delete-root3"
 		sub.Labels = map[string]string{constants.LabelParent: "delete-root3"}
-		Expect(k8sClient.Create(ctx, sub)).To(Succeed())
+		Eventually(k8sClient.Create(ctx, sub)).Should(Succeed())
 
 		sub = &corev1.Namespace{}
 		sub.Name = "sub-of-delete-root3"


### PR DESCRIPTION
While working on https://github.com/cybozu-go/accurate/pull/121 I noticed some flaky tests I have seen before in previous pull requests. Flakes are annoying, so this PR attempts to improve this somehow.

Since the webhook uses a caching client, the webhook might deny the request based on a non-updated cache. If the test creates a namespace referring to another namespace just created, this can make the test fail. Hopefully, this PR will improve the situation by replacing `Except` with `Eventually` in such cases.

I have also added assertions of error messages expected from the webhook for denied requests. This should prevent tests from passing if the request fails for any other reason than the expected. This will force us to update the test if error messages are changed, but I think this makes sense.