### PR TITLE
fix: upgrade SubNamespace status managed fields from CSA to SSA

### DIFF
--- a/controllers/ssa_client.go
+++ b/controllers/ssa_client.go
@@ -23,8 +23,8 @@ const (
 // fields from the Update operation to the Apply operation. This is required
 // to ensure that the apply operations will also remove fields that were
 // set by the Update operation.
-func upgradeManagedFields(ctx context.Context, c client.Client, obj client.Object) error {
-	patch, err := csaupgrade.UpgradeManagedFieldsPatch(obj, sets.New(string(fieldOwner)), string(fieldOwner))
+func upgradeManagedFields(ctx context.Context, c client.Client, obj client.Object, opts ...csaupgrade.Option) error {
+	patch, err := csaupgrade.UpgradeManagedFieldsPatch(obj, sets.New(string(fieldOwner)), string(fieldOwner), opts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR fixes the leftovers from https://github.com/cybozu-go/accurate/pull/121 and completes the operator migration from CSA to SSA. We should at some point remove the CSA to SSA upgrade code - as noted in the migration TODOs.

Would it be possible to cut a new release soon?