### PR TITLE
chore: deprecate v1 and v2alpha1 SubNamespace API

### DIFF
--- a/api/accurate/v1/subnamespace_types.go
+++ b/api/accurate/v1/subnamespace_types.go
@@ -28,8 +28,10 @@ type SubNamespaceSpec struct {
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:deprecatedversion:warning="The v1 version of SubNamespace has been deprecated and will be removed in a future release of the API. Please upgrade."
 
 // SubNamespace is the Schema for the subnamespaces API
+// Deprecated: This type will be removed in one of the next releases.
 type SubNamespace struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -46,6 +48,7 @@ type SubNamespace struct {
 //+kubebuilder:object:root=true
 
 // SubNamespaceList contains a list of SubNamespace
+// Deprecated: This type will be removed in one of the next releases.
 type SubNamespaceList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/accurate/v2alpha1/subnamespace_types.go
+++ b/api/accurate/v2alpha1/subnamespace_types.go
@@ -32,10 +32,12 @@ type SubNamespaceSpec struct {
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:deprecatedversion:warning="The v2alpha1 version of SubNamespace has been deprecated and will be removed in a future release of the API. Please upgrade."
 //+kubebuilder:subresource:status
 //+genclient
 
 // SubNamespace is the Schema for the subnamespaces API
+// Deprecated: This type will be removed in one of the next releases.
 type SubNamespace struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,6 +54,7 @@ type SubNamespace struct {
 //+kubebuilder:object:root=true
 
 // SubNamespaceList contains a list of SubNamespace
+// Deprecated: This type will be removed in one of the next releases.
 type SubNamespaceList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/charts/accurate/templates/generated/crds.yaml
+++ b/charts/accurate/templates/generated/crds.yaml
@@ -30,10 +30,14 @@ spec:
     singular: subnamespace
   scope: Namespaced
   versions:
-    - name: v1
+    - deprecated: true
+      deprecationWarning: The v1 version of SubNamespace has been deprecated and will be removed in a future release of the API. Please upgrade.
+      name: v1
       schema:
         openAPIV3Schema:
-          description: SubNamespace is the Schema for the subnamespaces API
+          description: |-
+            SubNamespace is the Schema for the subnamespaces API
+            Deprecated: This type will be removed in one of the next releases.
           properties:
             apiVersion:
               description: |-
@@ -184,10 +188,14 @@ spec:
       storage: true
       subresources:
         status: {}
-    - name: v2alpha1
+    - deprecated: true
+      deprecationWarning: The v2alpha1 version of SubNamespace has been deprecated and will be removed in a future release of the API. Please upgrade.
+      name: v2alpha1
       schema:
         openAPIV3Schema:
-          description: SubNamespace is the Schema for the subnamespaces API
+          description: |-
+            SubNamespace is the Schema for the subnamespaces API
+            Deprecated: This type will be removed in one of the next releases.
           properties:
             apiVersion:
               description: |-

--- a/config/crd/bases/accurate.cybozu.com_subnamespaces.yaml
+++ b/config/crd/bases/accurate.cybozu.com_subnamespaces.yaml
@@ -14,10 +14,15 @@ spec:
     singular: subnamespace
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: The v1 version of SubNamespace has been deprecated and will
+      be removed in a future release of the API. Please upgrade.
+    name: v1
     schema:
       openAPIV3Schema:
-        description: SubNamespace is the Schema for the subnamespaces API
+        description: |-
+          SubNamespace is the Schema for the subnamespaces API
+          Deprecated: This type will be removed in one of the next releases.
         properties:
           apiVersion:
             description: |-
@@ -172,10 +177,15 @@ spec:
     storage: true
     subresources:
       status: {}
-  - name: v2alpha1
+  - deprecated: true
+    deprecationWarning: The v2alpha1 version of SubNamespace has been deprecated and
+      will be removed in a future release of the API. Please upgrade.
+    name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: SubNamespace is the Schema for the subnamespaces API
+        description: |-
+          SubNamespace is the Schema for the subnamespaces API
+          Deprecated: This type will be removed in one of the next releases.
         properties:
           apiVersion:
             description: |-

--- a/docs/crd_subnamespace.md
+++ b/docs/crd_subnamespace.md
@@ -10,7 +10,7 @@
 
 #### SubNamespace
 
-SubNamespace is the Schema for the subnamespaces API
+SubNamespace is the Schema for the subnamespaces API Deprecated: This type will be removed in one of the next releases.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -22,7 +22,7 @@ SubNamespace is the Schema for the subnamespaces API
 
 #### SubNamespaceList
 
-SubNamespaceList contains a list of SubNamespace
+SubNamespaceList contains a list of SubNamespace Deprecated: This type will be removed in one of the next releases.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |


### PR DESCRIPTION
The v2alpha1 version of the SubNamespace API has been available for a while, and I think it's time to consider deprecating the v1 version. The newer version has a much better observed state UX with conditions. We should probably make v2 (or v2beta1) available - to not "scare" our users from migrating (to an alpha version).