### PR TITLE
fix: set default klog logger to avoid breaking log format

### DIFF
--- a/cmd/accurate-controller/sub/run.go
+++ b/cmd/accurate-controller/sub/run.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -28,8 +29,10 @@ import (
 )
 
 func subMain(ns, addr string, port int) error {
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&options.zapOpts)))
-	logger := ctrl.Log.WithName("setup")
+	logger := zap.New(zap.UseFlagOptions(&options.zapOpts))
+	ctrl.SetLogger(logger)
+	klog.SetLogger(logger)
+	logger = ctrl.Log.WithName("setup")
 
 	scheme := runtime.NewScheme()
 	if err := clientgoscheme.AddToScheme(scheme); err != nil {


### PR DESCRIPTION
We are using JSON log format in our installation of Accurate. Here is an example log:

````
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"controller-runtime.builder","msg":"skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called","GVK":"accurate.cybozu.com/v1, Kind=SubNamespace"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"controller-runtime.builder","msg":"skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called","GVK":"accurate.cybozu.com/v1, Kind=SubNamespace"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/convert"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"controller-runtime.builder","msg":"Conversion webhook enabled","GVK":"accurate.cybozu.com/v1, Kind=SubNamespace"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"controller-runtime.builder","msg":"skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called","GVK":"accurate.cybozu.com/v2alpha1, Kind=SubNamespace"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"controller-runtime.builder","msg":"skip registering a validating webhook, object does not implement admission.Validator or WithValidator wasn't called","GVK":"accurate.cybozu.com/v2alpha1, Kind=SubNamespace"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"controller-runtime.builder","msg":"Conversion webhook enabled","GVK":"accurate.cybozu.com/v2alpha1, Kind=SubNamespace"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/mutate-accurate-cybozu-com-v1-subnamespace"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/validate-accurate-cybozu-com-v1-subnamespace"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"setup","msg":"watching","gvk":"/v1, Kind=LimitRange"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"setup","msg":"watching","gvk":"/v1, Kind=ResourceQuota"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"setup","msg":"watching","gvk":"networking.k8s.io/v1, Kind=NetworkPolicy"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"setup","msg":"watching","gvk":"rbac.authorization.k8s.io/v1, Kind=Role"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"setup","msg":"watching","gvk":"rbac.authorization.k8s.io/v1, Kind=RoleBinding"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"setup","msg":"watching","gvk":"network.openshift.io/v1, Kind=EgressNetworkPolicy"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"setup","msg":"starting manager"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"controller-runtime.metrics","msg":"Starting metrics server"}
{"level":"info","ts":"2024-05-21T12:28:14Z","msg":"starting server","kind":"health probe","addr":"[::]:8081"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8080","secure":false}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"controller-runtime.webhook","msg":"Starting webhook server"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"controller-runtime.certwatcher","msg":"Updated current TLS certificate"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"controller-runtime.certwatcher","msg":"Starting certificate watcher"}
{"level":"info","ts":"2024-05-21T12:28:14Z","logger":"controller-runtime.webhook","msg":"Serving webhook server","host":"","port":9443}
I0521 12:28:15.237534 1 leaderelection.go:250] attempting to acquire leader lease accurate/accurate...
2024/05/21 12:29:04 http: TLS handshake error from 10.101.0.1:43356: EOF
2024/05/21 12:31:21 http: TLS handshake error from 10.101.0.1:48132: EOF
````

As you can see, the last three lines breaks the configured JSON log-format. I've digged into the origin of these log-lines, and it appears like it's logged from the default klog logger. This PR initializes the default klog logger and should fix this issue.

Related issue https://github.com/cybozu-go/accurate/issues/104.