### PR TITLE
fix: check RBAC to watched resources on startup

### DIFF
--- a/charts/accurate/MIGRATION.md
+++ b/charts/accurate/MIGRATION.md
@@ -114,7 +114,6 @@ controller:
           - list
           - watch
           - create
-          - update
           - patch
           - delete
 <snip>

--- a/charts/accurate/values.yaml
+++ b/charts/accurate/values.yaml
@@ -101,7 +101,6 @@ controller:
           - list
           - watch
           - create
-          - update
           - patch
           - delete
     # controller.additionalRBAC.clusterRoles -- Specify additional ClusterRoles to be granted

--- a/cmd/accurate-controller/sub/run.go
+++ b/cmd/accurate-controller/sub/run.go
@@ -89,8 +89,13 @@ func subMain(ns, addr string, port int) error {
 		return fmt.Errorf("unable to start manager: %w", err)
 	}
 
+	ctx := ctrl.SetupSignalHandler()
+
 	if err := cfg.Validate(mgr.GetRESTMapper()); err != nil {
 		return fmt.Errorf("invalid configurations: %w", err)
+	}
+	if err := cfg.ValidateRBAC(ctx, mgr.GetClient(), mgr.GetRESTMapper()); err != nil {
+		return fmt.Errorf("when validating RBAC to support configuration: %w", err)
 	}
 
 	watched := make([]*unstructured.Unstructured, len(cfg.Watches))
@@ -104,7 +109,6 @@ func subMain(ns, addr string, port int) error {
 		})
 	}
 
-	ctx := ctrl.SetupSignalHandler()
 	dec := admission.NewDecoder(scheme)
 
 	// Namespace reconciler & webhook

--- a/docs/config.md
+++ b/docs/config.md
@@ -162,7 +162,6 @@ controller:
           - list
           - watch
           - create
-          - update
           - patch
           - delete
 <snip>

--- a/e2e/values.yaml
+++ b/e2e/values.yaml
@@ -54,7 +54,6 @@ controller:
           - list
           - watch
           - create
-          - update
           - patch
           - delete
     clusterRoles:

--- a/pkg/config/suite_test.go
+++ b/pkg/config/suite_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/restmapper"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -22,6 +23,8 @@ import (
 
 var testEnv *envtest.Environment
 var mapper meta.RESTMapper
+var fullAccessClient client.Client
+var noAccessClient client.Client
 
 func TestAPIs(t *testing.T) {
 	if os.Getenv("TEST_CONFIG") != "1" {
@@ -41,6 +44,13 @@ var _ = BeforeSuite(func() {
 	cfg, err := testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
+	fullAccessClient, err = client.New(cfg, client.Options{})
+	Expect(err).NotTo(HaveOccurred())
+
+	noAccessUser, err := testEnv.AddUser(envtest.User{Name: "no-access-user"}, nil)
+	Expect(err).NotTo(HaveOccurred())
+	noAccessClient, err = client.New(noAccessUser.Config(), client.Options{})
+	Expect(err).NotTo(HaveOccurred())
 
 	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This PR adds more validation of configuration on startup. The operator must have cluster-wide RBAC to CRUD all configured watches to function as intended by the user. At startup, we will now use [SelfSubjectAccessReview](https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1/) to check the required RBAC for all configured watches and crash if anything is missing.

Note: After migrating to SSA, we no longer need the `update` verb. I included this minor change in this PR, but please let me know if a dedicated PR is required.

Close https://github.com/cybozu-go/accurate/issues/102