### PR TITLE
chore: change stored version of API to v2

### DIFF
--- a/api/accurate/v2/subnamespace_types.go
+++ b/api/accurate/v2/subnamespace_types.go
@@ -32,6 +32,7 @@ type SubNamespaceSpec struct {
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:storageversion
 //+kubebuilder:subresource:status
 //+genclient
 

--- a/api/accurate/v2alpha1/subnamespace_types.go
+++ b/api/accurate/v2alpha1/subnamespace_types.go
@@ -32,7 +32,6 @@ type SubNamespaceSpec struct {
 }
 
 //+kubebuilder:object:root=true
-//+kubebuilder:storageversion
 //+kubebuilder:subresource:status
 //+genclient
 

--- a/charts/accurate/templates/generated/crds.yaml
+++ b/charts/accurate/templates/generated/crds.yaml
@@ -181,7 +181,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - name: v2alpha1
@@ -290,7 +290,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
 {{- end }}

--- a/config/crd/bases/accurate.cybozu.com_subnamespaces.yaml
+++ b/config/crd/bases/accurate.cybozu.com_subnamespaces.yaml
@@ -169,7 +169,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - name: v2alpha1
@@ -281,6 +281,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}

--- a/controllers/namespace_controller.go
+++ b/controllers/namespace_controller.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"path"
 
-	accuratev2alpha1 "github.com/cybozu-go/accurate/api/accurate/v2alpha1"
+	accuratev2 "github.com/cybozu-go/accurate/api/accurate/v2"
 	utilerrors "github.com/cybozu-go/accurate/internal/util/errors"
 	"github.com/cybozu-go/accurate/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
@@ -101,7 +101,7 @@ func (r *NamespaceReconciler) propagateMeta(ctx context.Context, ns, parent *cor
 	}
 
 	if _, ok := ns.Labels[constants.LabelParent]; ok {
-		subNS := &accuratev2alpha1.SubNamespace{}
+		subNS := &accuratev2.SubNamespace{}
 		err := r.Get(ctx, types.NamespacedName{Name: ns.Name, Namespace: parent.Name}, subNS)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
@@ -402,7 +402,7 @@ func (r *NamespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Namespace{}).
-		Watches(&accuratev2alpha1.SubNamespace{}, handler.Funcs{
+		Watches(&accuratev2.SubNamespace{}, handler.Funcs{
 			CreateFunc: func(ctx context.Context, ev event.CreateEvent, q workqueue.RateLimitingInterface) {
 				subNSHandler(ev.Object, q)
 			},

--- a/controllers/namespace_controller_test.go
+++ b/controllers/namespace_controller_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	accuratev2alpha1 "github.com/cybozu-go/accurate/api/accurate/v2alpha1"
+	accuratev2 "github.com/cybozu-go/accurate/api/accurate/v2"
 	"github.com/cybozu-go/accurate/pkg/constants"
 	"github.com/cybozu-go/accurate/pkg/indexing"
 	. "github.com/onsi/ginkgo/v2"
@@ -431,7 +431,7 @@ var _ = Describe("Namespace controller", func() {
 		Expect(komega.Get(gcSec2)()).To(Succeed())
 
 		By("creating a SubNamespace for sub1 namespace")
-		sn := &accuratev2alpha1.SubNamespace{}
+		sn := &accuratev2.SubNamespace{}
 		sn.Namespace = "root"
 		sn.Name = "sub1"
 		sn.Spec.Labels = map[string]string{
@@ -483,7 +483,7 @@ var _ = Describe("Namespace controller", func() {
 		Expect(komega.Get(ns)()).To(Succeed())
 		Expect(ns.Labels).To(HaveKeyWithValue("bar.glob/l", "delete-me"))
 		Expect(ns.Annotations).To(HaveKeyWithValue("bar.glob/a", "delete-me"))
-		sn := &accuratev2alpha1.SubNamespace{}
+		sn := &accuratev2.SubNamespace{}
 		sn.Name = "pre-ssa-child"
 		sn.Namespace = "pre-ssa-root"
 		Expect(komega.Update(sn, func() {

--- a/controllers/ssa_client.go
+++ b/controllers/ssa_client.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
-	accuratev2alpha1 "github.com/cybozu-go/accurate/api/accurate/v2alpha1"
-	accuratev2alpha1ac "github.com/cybozu-go/accurate/internal/applyconfigurations/accurate/v2alpha1"
+	accuratev2 "github.com/cybozu-go/accurate/api/accurate/v2"
+	accuratev2ac "github.com/cybozu-go/accurate/internal/applyconfigurations/accurate/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -35,8 +35,8 @@ func upgradeManagedFields(ctx context.Context, c client.Client, obj client.Objec
 	return nil
 }
 
-func newSubNamespacePatch(ac *accuratev2alpha1ac.SubNamespaceApplyConfiguration) (*accuratev2alpha1.SubNamespace, client.Patch, error) {
-	sn := &accuratev2alpha1.SubNamespace{}
+func newSubNamespacePatch(ac *accuratev2ac.SubNamespaceApplyConfiguration) (*accuratev2.SubNamespace, client.Patch, error) {
+	sn := &accuratev2.SubNamespace{}
 	sn.Name = *ac.Name
 	sn.Namespace = *ac.Namespace
 

--- a/controllers/subnamespace_controller_test.go
+++ b/controllers/subnamespace_controller_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	accuratev2alpha1 "github.com/cybozu-go/accurate/api/accurate/v2alpha1"
+	accuratev2 "github.com/cybozu-go/accurate/api/accurate/v2"
 	"github.com/cybozu-go/accurate/pkg/constants"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -55,7 +55,7 @@ var _ = Describe("SubNamespace controller", func() {
 		ns.Name = "test1"
 		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
-		sn := &accuratev2alpha1.SubNamespace{}
+		sn := &accuratev2.SubNamespace{}
 		sn.Namespace = "test1"
 		sn.Name = "test1-sub1"
 		sn.Finalizers = []string{constants.Finalizer}
@@ -84,14 +84,14 @@ var _ = Describe("SubNamespace controller", func() {
 		ns2.Name = "test2-sub1"
 		Expect(k8sClient.Create(ctx, ns2)).To(Succeed())
 
-		sn := &accuratev2alpha1.SubNamespace{}
+		sn := &accuratev2.SubNamespace{}
 		sn.Namespace = "test2"
 		sn.Name = "test2-sub1"
 		Expect(k8sClient.Create(ctx, sn)).To(Succeed())
 
 		Eventually(komega.Object(sn)).Should(HaveField("Status.ObservedGeneration", BeNumerically(">", 0)))
 		Expect(sn.Status.Conditions).To(HaveLen(1))
-		Expect(sn.Status.Conditions[0].Reason).To(Equal(accuratev2alpha1.SubNamespaceConflict))
+		Expect(sn.Status.Conditions[0].Reason).To(Equal(accuratev2.SubNamespaceConflict))
 	})
 
 	It("should not delete a conflicting sub namespace", func() {
@@ -99,7 +99,7 @@ var _ = Describe("SubNamespace controller", func() {
 		ns.Name = "test3"
 		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
-		sn := &accuratev2alpha1.SubNamespace{}
+		sn := &accuratev2.SubNamespace{}
 		sn.Namespace = "test3"
 		sn.Name = "test3-sub1"
 		sn.Finalizers = []string{constants.Finalizer}
@@ -114,7 +114,7 @@ var _ = Describe("SubNamespace controller", func() {
 		})()).To(Succeed())
 
 		Eventually(komega.Object(sn)).Should(HaveField("Status.Conditions", HaveLen(1)))
-		Expect(sn.Status.Conditions[0].Reason).To(Equal(accuratev2alpha1.SubNamespaceConflict))
+		Expect(sn.Status.Conditions[0].Reason).To(Equal(accuratev2.SubNamespaceConflict))
 
 		Expect(k8sClient.Delete(ctx, sn)).To(Succeed())
 
@@ -126,7 +126,7 @@ var _ = Describe("SubNamespace controller", func() {
 		ns.Name = "test4"
 		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
-		sn := &accuratev2alpha1.SubNamespace{}
+		sn := &accuratev2.SubNamespace{}
 		sn.Namespace = "test4"
 		sn.Name = "test4-sub1"
 		Expect(k8sClient.Create(ctx, sn)).To(Succeed())

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -123,7 +123,7 @@ var _ = BeforeSuite(func() {
 	ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
 	Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
 
-	sn := &accuratev2alpha1.SubNamespace{}
+	sn := &accuratev2.SubNamespace{}
 	sn.Name = "pre-ssa-child"
 	sn.Namespace = "pre-ssa-root"
 	sn.Spec.Labels = map[string]string{


### PR DESCRIPTION
This PR changes the stored version from v2alpha1 to v2, ref. https://github.com/cybozu-go/accurate/pull/132. Also changing the controller to use the new stored version to avoid an excessive number of conversions.