### PR TITLE
fix: improve CRD install (Helm and standalone)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ HELM_CRDS_FILE := charts/accurate/templates/generated/crds.yaml
 .PHONY: manifests
 manifests: setup ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	controller-gen $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="{./api/..., ./controllers/..., ./hooks/...}" output:crd:artifacts:config=config/crd/bases
-	echo '{{- if .Values.installCRDs }}' > $(HELM_CRDS_FILE)
+	echo '{{- include "accurate.crd-check" . }}' > $(HELM_CRDS_FILE)
+	echo '{{- if or .Values.crds.enabled .Values.installCRDs }}' >> $(HELM_CRDS_FILE)
 	kustomize build config/kustomize-to-helm/overlays/crds | yq e "." -p yaml - >> $(HELM_CRDS_FILE)
 	echo '{{- end }}' >> $(HELM_CRDS_FILE)
 	kustomize build config/kustomize-to-helm/overlays/templates | yq e "."  -p yaml - > charts/accurate/templates/generated/generated.yaml

--- a/charts/accurate/templates/NOTES.txt
+++ b/charts/accurate/templates/NOTES.txt
@@ -1,0 +1,3 @@
+{{- if not .Values.installCRDs }}
+⚠️  WARNING: `installCRDs` is deprecated, use `crds.enabled` instead.
+{{- end }}

--- a/charts/accurate/templates/_helpers.tpl
+++ b/charts/accurate/templates/_helpers.tpl
@@ -37,3 +37,17 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+
+{{/*
+Check that the user has not unset both .installCRDs and .crds.enabled or
+set .installCRDs and disabled .crds.keep.
+.installCRDs is deprecated and users should use .crds.enabled and .crds.keep instead.
+*/}}
+{{- define "accurate.crd-check" -}}
+  {{- if and ( not .Values.installCRDs) (not .Values.crds.enabled) }}
+    {{- fail "ERROR: the deprecated .installCRDs option cannot be disabled at the same time as its replacement .crds.enabled" }}
+  {{- end }}
+  {{- if and (.Values.installCRDs) (not .Values.crds.keep) }}
+    {{- fail "ERROR: .crds.keep is not compatible with .installCRDs, please use .crds.enabled and .crds.keep instead" }}
+  {{- end }}
+{{- end -}}

--- a/charts/accurate/templates/generated/crds.yaml
+++ b/charts/accurate/templates/generated/crds.yaml
@@ -1,10 +1,12 @@
-{{- if .Values.installCRDs }}
+{{- include "accurate.crd-check" . }}
+{{- if or .Values.crds.enabled .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ template "accurate.fullname" . }}-serving-cert'
     controller-gen.kubebuilder.io/version: v0.15.0
+    helm.sh/resource-policy: '{{ .Values.crds.keep | ternary "keep" "delete" }}'
   labels:
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/name: '{{ include "accurate.name" . }}'

--- a/charts/accurate/values.yaml
+++ b/charts/accurate/values.yaml
@@ -1,4 +1,17 @@
+# Deprecated: Use crds.enabled and crds.keep instead.
 installCRDs: true
+
+crds:
+  # This option decides if the CRDs should be installed
+  # as part of the Helm installation.
+  enabled: true
+
+  # This option makes it so that the "helm.sh/resource-policy": keep
+  # annotation is added to the CRD. This will prevent Helm from uninstalling
+  # the CRD when the Helm release is uninstalled.
+  # WARNING: when the CRDs are removed, all Accurate custom resources
+  # like subnamespaces will be removed too by the garbage collector.
+  keep: true
 
 image:
   # image.repository -- Accurate image repository to use.

--- a/config/crd-only/crd_conversion_patch.yaml
+++ b/config/crd-only/crd_conversion_patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: accurate/accurate-serving-cert
+  name: subnamespaces.accurate.cybozu.com
+spec:
+  conversion:
+    webhook:
+      clientConfig:
+        service:
+          namespace: accurate
+          name: accurate-webhook-service

--- a/config/crd-only/kustomization.yaml
+++ b/config/crd-only/kustomization.yaml
@@ -1,0 +1,7 @@
+labels:
+  - pairs:
+      app.kubernetes.io/name: accurate
+resources:
+- ../crd
+patches:
+  - path: crd_conversion_patch.yaml

--- a/config/kustomize-to-helm/overlays/crds/crd_resource_policy_patch.yaml
+++ b/config/kustomize-to-helm/overlays/crds/crd_resource_policy_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: '{{ .Values.crds.keep | ternary "keep" "delete" }}'
+  name: subnamespaces.accurate.cybozu.com

--- a/config/kustomize-to-helm/overlays/crds/kustomization.yaml
+++ b/config/kustomize-to-helm/overlays/crds/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
 
 patches:
   - path: crd_conversion_patch.yaml
+  - path: crd_resource_policy_patch.yaml
 
 components:
   - ../../components/common-labels


### PR DESCRIPTION
The purpose of this PR is twofold: fix the currently broken CRDs standalone install (https://github.com/cybozu-go/accurate/issues/139) and improve the Helm CRDs install by adding `helm.sh/resource-policy: keep` annotation (by default) to CRDs to prevent Helm from uninstalling the CRD when the Helm release is uninstalled. The general improvement of Helm CRD install will hopefully allow more users to let Helm manage CRDs.

I will suggest publishing CRDs as a release artifact to avoid the new `crd-only` kustomize overlay. As long as we have conversion webhooks, installing CRDs separately will be somehow borked.

The solution is heavily inspired by recent work in cert-manager!

Fixes https://github.com/cybozu-go/accurate/issues/139