### PR TITLE
fix(helm): correct invalid ConfigMap template

### DIFF
--- a/charts/accurate/templates/configmap.yaml
+++ b/charts/accurate/templates/configmap.yaml
@@ -20,12 +20,12 @@ data:
     subNamespaceAnnotationKeys: {{ toYaml . | nindent 6 }}
     {{- end }}
     watches: {{ toYaml .Values.controller.config.watches | nindent 6 }}
-    {{- with .Values.controller.config.namingPolicies }}
     {{- with .Values.controller.config.propagateLabelKeyExcludes }}
     propagateLabelKeyExcludes: {{ toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.controller.config.propagateAnnotationKeyExcludes }}
     propagateAnnotationKeyExcludes: {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.controller.config.namingPolicies }}
     namingPolicies: {{ toYaml . | nindent 6 }}
     {{- end }}


### PR DESCRIPTION
This corrects a bug in https://github.com/cybozu-go/accurate/pull/142. Without this fix, the Helm chart rendering is erroring out with:

````
Error: Error: template: accurate/templates/deployment.yaml:18:28: executing "accurate/templates/deployment.yaml" at <include (print $.Template.BasePath "/configmap.yaml") .>: error calling include: template: accurate/templates/configmap.yaml:24:20: executing "accurate/templates/configmap.yaml" at <.Values.controller.config.propagateLabelKeyExcludes>: can't evaluate field Values in type []interface {}
````

Sorry for this, but this is a blocking error that will require a new patch release (of the Helm chart, at least).

CC @zoetrope @ymmt2005 