### PR TITLE
fix(webhook): deny deletion of SubNamespace with child namespaces

### DIFF
--- a/charts/accurate/templates/generated/generated.yaml
+++ b/charts/accurate/templates/generated/generated.yaml
@@ -297,7 +297,7 @@ webhooks:
           - v1
         operations:
           - CREATE
-          - UPDATE
+          - DELETE
         resources:
           - subnamespaces
     sideEffects: None

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -69,7 +69,7 @@ webhooks:
     - v1
     operations:
     - CREATE
-    - UPDATE
+    - DELETE
     resources:
     - subnamespaces
   sideEffects: None


### PR DESCRIPTION
If a client is allowed to delete a `SubNamespace` where the sub-namespace has child namespaces, the controller becomes stuck on the finalization of the `SubNamespace`. The controller will not be allowed to delete the sub-namespaces by our namespace webhook.

Since Kubernetes has no way to undelete a resource (unset the `deletionTimestamp` field), all child namespaces must be manually deleted to allow the `SubNamespace` deletion to be finalized.

This PR introduces handling of DELETE verb to the subnamespaces validating webhook ensuring no subnamespaces can be deleted if the sub-namespace has child namespaces. It seems like there was a minor bug in the validating webhook configuration: it was configured to handle UPDATE verb, but the implementation was only addressing CREATE.

Close https://github.com/cybozu-go/accurate/issues/144