### PR TITLE
fix: should resolve SubNamespace conflict when sub-namespace deleted

### DIFF
--- a/cmd/accurate-controller/sub/run.go
+++ b/cmd/accurate-controller/sub/run.go
@@ -133,6 +133,9 @@ func subMain(ns, addr string, port int) error {
 	hooks.SetupNamespaceWebhook(mgr, dec)
 
 	// SubNamespace reconciler & webhook
+	if err := indexing.SetupIndexForSubNamespace(ctx, mgr); err != nil {
+		return fmt.Errorf("failed to setup indexer for subnamespaces: %w", err)
+	}
 	if err = (&controllers.SubNamespaceReconciler{
 		Client: mgr.GetClient(),
 	}).SetupWithManager(mgr); err != nil {

--- a/e2e/testdata/conflicting-subnamespace.yaml
+++ b/e2e/testdata/conflicting-subnamespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: accurate.cybozu.com/v2
+kind: SubNamespace
+metadata:
+  name: conflict-sub1
+  namespace: conflict-root1

--- a/pkg/constants/indexer.go
+++ b/pkg/constants/indexer.go
@@ -5,4 +5,5 @@ const (
 	NamespaceParentKey   = "namespace.parent"
 	NamespaceTemplateKey = "namespace.template"
 	PropagateKey         = "resource.propagate"
+	SubNamespaceNameKey  = "subnamespace.name"
 )

--- a/pkg/indexing/indexing.go
+++ b/pkg/indexing/indexing.go
@@ -3,6 +3,7 @@ package indexing
 import (
 	"context"
 
+	accuratev2 "github.com/cybozu-go/accurate/api/accurate/v2"
 	"github.com/cybozu-go/accurate/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,7 +24,7 @@ func SetupIndexForResource(ctx context.Context, mgr manager.Manager, res client.
 // SetupIndexForNamespace sets up indexers for namespaces.
 func SetupIndexForNamespace(ctx context.Context, mgr manager.Manager) error {
 	ns := &corev1.Namespace{}
-	err := mgr.GetFieldIndexer().IndexField(context.Background(), ns, constants.NamespaceParentKey, func(rawObj client.Object) []string {
+	err := mgr.GetFieldIndexer().IndexField(ctx, ns, constants.NamespaceParentKey, func(rawObj client.Object) []string {
 		parent := rawObj.GetLabels()[constants.LabelParent]
 		if parent == "" {
 			return nil
@@ -40,5 +41,12 @@ func SetupIndexForNamespace(ctx context.Context, mgr manager.Manager) error {
 			return nil
 		}
 		return []string{tmpl}
+	})
+}
+
+// SetupIndexForSubNamespace sets up indexers for subnamespaces.
+func SetupIndexForSubNamespace(ctx context.Context, mgr manager.Manager) error {
+	return mgr.GetFieldIndexer().IndexField(ctx, &accuratev2.SubNamespace{}, constants.SubNamespaceNameKey, func(rawObj client.Object) []string {
+		return []string{rawObj.GetName()}
 	})
 }


### PR DESCRIPTION
#### Background

Our tenants use GitOps to provision sub-namespaces, and not `kubectl-accurate`. We run on OpenShift, and OpenShift has a feature allowing users in the `self-provisioner` cluster role to create namespaces by issuing a ProjectRequest create request.   We want to migrate to Accurate, but will still have to support the OpenShift mechanism for a long time.

#### Problem (solved in this PR)

Recently we've had users pre-creating an OpenShift Project before provisioning the _SubNamespace_ resource that is supposed to control the desired namespace. This will not work, making the subnamespace enter a conflicting state right after creation by the tenant GitOps. The user observes this problem by inspecting the _SubNamespace_ status and other GitOps failures caused by missing RBAC in the target namespace.

The natural thing to do when this happens, is to delete the OpenShift `Project` resource currently controlling the (empty) target namespace. When the project is deleted, OpenShift will terminate the controlled namespace. So far, so good.

Expected behavior: Accurate detects the namespace deletion and (re)creates the target namespace as sub-namespace, resolving the conflict state on the _SubNamespace_.

Actual behavior: Accurate eventually acts on the deleted namespace, resolving the conflict state, but this is not happening in a timely fashion. The exact time depends on the resync time initiated regularly by controller-runtime. But we have seen this take several hours, which is not acceptable.