### PR TITLE
Update upload-artifact and download-artifact

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
     - run: make logs
       working-directory: e2e
       if: always()
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: logs-${{ matrix.k8s-version }}.tar.gz

--- a/.github/workflows/mdbook.yaml
+++ b/.github/workflows/mdbook.yaml
@@ -14,7 +14,7 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - run: make book
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: book
         path: docs/book
@@ -29,7 +29,7 @@ jobs:
         ref: gh-pages
     # ignore helm chart index file and chart archive file.
     - run: ls | grep -v -E 'index.yaml|accurate-.*\.tgz' | xargs rm -rf
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: book
     - run: git add .


### PR DESCRIPTION
upload-artifact and download-artifact were deprecated by 2024/11/30.
https://github.com/actions/download-artifact