### PR TITLE
Fix N+1 Issue in Namespace Search and Enhance Tree View

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SUDO = sudo
 SHELL = /bin/bash
 .SHELLFLAGS = -e -o pipefail -c
 
-PATH := $(shell aqua root-dir)/bin:$(PATH)"
+PATH := $(shell aqua root-dir)/bin:$(PATH)
 export PATH
 
 CRD_OPTIONS = "crd:crdVersions=v1,maxDescLen=220"

--- a/cmd/kubectl-accurate/sub/list.go
+++ b/cmd/kubectl-accurate/sub/list.go
@@ -3,6 +3,7 @@ package sub
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/cybozu-go/accurate/pkg/constants"
 	"github.com/spf13/cobra"
@@ -11,8 +12,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-const indent = 4
 
 type listOptions struct {
 	streams genericiooptions.IOStreams
@@ -57,45 +56,76 @@ func (o *listOptions) Fill(streams genericiooptions.IOStreams, config *genericcl
 }
 
 func (o *listOptions) Run(ctx context.Context) error {
-	if o.root != "" {
-		return o.showNS(ctx, o.root, 0)
+	allNamespaces := &corev1.NamespaceList{}
+	if err := o.client.List(ctx, allNamespaces); err != nil {
+		return fmt.Errorf("failed to list all namespaces: %w", err)
 	}
 
-	roots := &corev1.NamespaceList{}
-	if err := o.client.List(ctx, roots, client.MatchingLabels{constants.LabelType: constants.NSTypeRoot}); err != nil {
-		return fmt.Errorf("failed to list the root namespaces: %w", err)
-	}
+	sort.Slice(allNamespaces.Items, func(i, j int) bool {
+		return allNamespaces.Items[i].Name < allNamespaces.Items[j].Name
+	})
 
-	for _, ns := range roots.Items {
-		if err := o.showNS(ctx, ns.Name, 0); err != nil {
-			return err
+	nsMap := make(map[string]*corev1.Namespace)
+	childMap := make(map[string][]*corev1.Namespace)
+
+	for i := range allNamespaces.Items {
+		ns := &allNamespaces.Items[i]
+		nsMap[ns.Name] = ns
+		if parent, ok := ns.Labels[constants.LabelParent]; ok {
+			childMap[parent] = append(childMap[parent], ns)
 		}
 	}
+
+	for _, children := range childMap {
+		sort.Slice(children, func(i, j int) bool {
+			return children[i].Name < children[j].Name
+		})
+	}
+
+	var roots []*corev1.Namespace
+	if o.root != "" {
+		if rootNS, exists := nsMap[o.root]; exists {
+			roots = append(roots, rootNS)
+		} else {
+			return fmt.Errorf("namespace %s not found. ensure the namespace exists and is correctly labeled", o.root)
+		}
+	} else {
+		for _, ns := range allNamespaces.Items {
+			if ns.Labels[constants.LabelType] == constants.NSTypeRoot {
+				roots = append(roots, &ns)
+			}
+		}
+	}
+
+	sort.Slice(roots, func(i, j int) bool {
+		return roots[i].Name < roots[j].Name
+	})
+
+	for i, root := range roots {
+		o.showNSRecursive(root, childMap, "", i == len(roots)-1)
+	}
+
 	return nil
 }
 
-func (o *listOptions) showNS(ctx context.Context, name string, level int) error {
-	ns := &corev1.Namespace{}
-	if err := o.client.Get(ctx, client.ObjectKey{Name: name}, ns); err != nil {
-		return fmt.Errorf("failed to get namespace %s: %w", name, err)
+func (o *listOptions) showNSRecursive(ns *corev1.Namespace, childMap map[string][]*corev1.Namespace, prefix string, isLast bool) {
+	branch := "├── "
+	if isLast {
+		branch = "└── "
+	}
+	fmt.Fprintf(o.streams.Out, "%s%s%s\n", prefix, branch, ns.Name)
+
+	newPrefix := prefix
+	if isLast {
+		newPrefix += "    "
+	} else {
+		newPrefix += "│   "
 	}
 
-	subMark := " "
-	if _, ok := ns.Labels[constants.LabelParent]; ok {
-		subMark = "⮡"
-	}
-	fmt.Fprintf(o.streams.Out, "%*s%s%s\n", level, "", subMark, name)
+	children := childMap[ns.Name]
+	numChildren := len(children)
 
-	children := &corev1.NamespaceList{}
-	if err := o.client.List(ctx, children, client.MatchingLabels{constants.LabelParent: name}); err != nil {
-		return fmt.Errorf("failed to list the children of %s: %w", name, err)
+	for i, child := range children {
+		o.showNSRecursive(child, childMap, newPrefix, i == numChildren-1)
 	}
-
-	level += indent
-	for _, child := range children.Items {
-		if err := o.showNS(ctx, child.Name, level); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/cmd/kubectl-accurate/sub/list.go
+++ b/cmd/kubectl-accurate/sub/list.go
@@ -76,12 +76,6 @@ func (o *listOptions) Run(ctx context.Context) error {
 		}
 	}
 
-	for _, children := range childMap {
-		sort.Slice(children, func(i, j int) bool {
-			return children[i].Name < children[j].Name
-		})
-	}
-
 	var roots []*corev1.Namespace
 	if o.root != "" {
 		if rootNS, exists := nsMap[o.root]; exists {

--- a/cmd/kubectl-accurate/sub/template_list.go
+++ b/cmd/kubectl-accurate/sub/template_list.go
@@ -76,12 +76,6 @@ func (o *templateListOpts) Run(ctx context.Context) error {
 		}
 	}
 
-	for _, children := range childMap {
-		sort.Slice(children, func(i, j int) bool {
-			return children[i].Name < children[j].Name
-		})
-	}
-
 	var roots []*corev1.Namespace
 	if o.template != "" {
 		if rootNS, exists := nsMap[o.template]; exists {


### PR DESCRIPTION
## Overview
- Resolved the N+1 problem by optimizing namespace retrieval for faster searches.
- Fixed tree display indentation using tree symbols.
## Fixes
- Optimized namespace hierarchy retrieval to eliminate redundant queries.
- Improved tree view formatting by using tree symbols and removing unnecessary indent variables.
- Sorted namespaces in ascending alphabetical order.
## Rationale
- The current implementation suffers from an N+1 problem when searching namespaces, leading to poor performance.
- This update improves user experience by significantly speeding up namespace lookups.