### PR TITLE
Build multiarch image

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -18,6 +18,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.13
+
+      - name: set up a buildkit builder
+        # --driver docker-container is required to get a builder that can build multi-arch.
+        # --driver-opt network=host is required to be able to push to the kind registry, which is sitting on the host at :5000.
+        run: |
+          docker buildx create --name=b --driver docker-container --driver-opt network=host
+          docker buildx use b
+
       - name: Set up chart-testing
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
 
@@ -33,22 +41,28 @@ jobs:
         run: ct lint --config ct.yaml
 
       - name: Create kind cluster
+        id: kind
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
           node_image: kindest/node:v1.31.4
+          registry: true
+          registry_name: kind-registry
+          registry_port: 5000
       - name: Apply cert-manager
         run: |
           kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
           kubectl -n cert-manager wait --for=condition=available --timeout=180s --all deployments
       - name: Prepare values.yaml
         run: |
-          docker build -t accurate:dev .
-          kind load docker-image accurate:dev --name=chart-testing
+          docker buildx build \
+            --platform arm64,amd64 \
+            --output type=registry,name=${{ steps.kind.outputs.LOCAL_REGISTRY }}/accurate:dev,push=true,registry.insecure=true,compression=zstd \
+            .
           mkdir -p charts/accurate/ci/
           cat > charts/accurate/ci/ci-values.yaml <<EOF
           image:
-            repository: accurate
+            repository: ${{ steps.kind.outputs.LOCAL_REGISTRY }}/accurate
             tag: dev
             pullPolicy: Never
           EOF

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,16 +9,19 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
+    - name: Setup
+      run: |
+        docker buildx create --name=b --driver docker-container
+        docker buildx use b
+        echo "TAG=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
     - name: Build images
       run: |
-        docker build -t accurate:dev .
+        docker buildx build --platform=arm64,amd64 -t ghcr.io/cybozu-go/accurate:$TAG .
     - name: Login to ghcr.io
       run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
     - name: Push images
       run: |
-        TAG=${GITHUB_REF#refs/tags/v}
-        docker tag accurate:dev ghcr.io/cybozu-go/accurate:$TAG
-        docker push ghcr.io/cybozu-go/accurate:$TAG
+        docker buildx build --platform=arm64,amd64 -t ghcr.io/cybozu-go/accurate:$TAG . --push
   release:
     name: Release on GitHub
     needs: image

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM --platform=$BUILDPLATFORM ghcr.io/cybozu/golang:1.23-jammy AS builder
 COPY ./ .
 
 # Build the binary, cross-compiling if necessary
-ARG TARGETPLATFORM
-RUN CGO_ENABLED=0 GOOS=linux GOOARCH=$TARGETPLATFORM \
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH \
 	go build -ldflags="-w -s" -o accurate-controller ./cmd/accurate-controller
 
 # the controller image, this is in the target architecture.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
-# Build the manager binary
-FROM ghcr.io/cybozu/golang:1.23-jammy as builder
+# Build the manager binary. This always executes in the native architecture of the building machine.
+FROM --platform=$BUILDPLATFORM ghcr.io/cybozu/golang:1.23-jammy AS builder
 
 COPY ./ .
-RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o accurate-controller ./cmd/accurate-controller
 
-# the controller image
+# Build the binary, cross-compiling if necessary
+ARG TARGETPLATFORM
+RUN CGO_ENABLED=0 GOOS=linux GOOARCH=$TARGETPLATFORM \
+	go build -ldflags="-w -s" -o accurate-controller ./cmd/accurate-controller
+
+# the controller image, this is in the target architecture.
 FROM scratch
 LABEL org.opencontainers.image.source https://github.com/cybozu-go/accurate
 


### PR DESCRIPTION
As per https://github.com/cybozu-go/accurate/issues/155 , this makes the CI build a multi-arch image.

The image is built using `buildx`, as per https://docs.docker.com/build/building/multi-platform/#prerequisites - Custom Builder .

On the dockerfile side, I've done it by using Go's cross-compilation abilities. The build stage is always host-native, and the binary is cross-compiled where necessary. This is the fastest way of doing things and works well for pure Go projects like this.

On the CI side, the Helm check needed to change a little bit: docker's local store can't handle multi-arch images, so instead of building to the local store and then using `kind load docker-image`, we set up a kind registry and push straight into that instead.

In addition, I've set the image to compress with `zstd` as it improves performance on container start a bit.

I can only test the release system so much as I don't have your ghcr keys :)