### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We're extremely grateful for security researchers and users that report vulnerabilities.
+All reports are thoroughly investigated by our team and a set of community volunteers in a reasonable timeframe.
+
+To report a vulnerability, submit your vulnerability via the [GitHub Security Advisories](https://github.com/cybozu-go/accurate/security/advisories/new).
+You can also email the private <neco@cybozu.com> list with the security details of your reports.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,16 @@
 
 ## Reporting a Vulnerability
 
-We're extremely grateful for security researchers and users that report vulnerabilities.
-All reports are thoroughly investigated by our team and a set of community volunteers in a reasonable timeframe.
+Security reports are investigated by the project maintainers and resolved within a reasonable timeframe.
 
-To report a vulnerability, submit your vulnerability via the [GitHub Security Advisories](https://github.com/cybozu-go/accurate/security/advisories/new).
-You can also email the private <neco@cybozu.com> list with the security details of your reports.
+To report a security vulnerability, please use GitHub's [private security reporting](https://github.com/cybozu-go/accurate/security/advisories/new). This allows the reporter and maintainers to coordinate the disclosure and fix before public disclosure.
+
+For more information about private security reporting, see the [GitHub documentation](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
+
+## Supported Versions
+
+We provide security updates only for the latest released version of Accurate.
+
+## Embargo Policy
+
+Vulnerability information is kept confidential until a fix is released. If you accidentally disclose information, please contact us immediately.


### PR DESCRIPTION
Add SECURITY.md depends on the following guidelines.

- https://contribute.cncf.io/maintainers/security/security-guidelines/
- https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository