### PR TITLE
Fix use of deprecated Ginkgo progress option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,11 @@ check-generate:
 .PHONY: envtest
 envtest: setup-envtest
 	source <($(SETUP_ENVTEST) use -p env); \
-		TEST_CONFIG=1 go test -v -count 1 -race ./pkg/config -ginkgo.progress -ginkgo.v -ginkgo.fail-fast
+		TEST_CONFIG=1 go test -v -count 1 -race ./pkg/config -ginkgo.show-node-events -ginkgo.v -ginkgo.fail-fast
 	source <($(SETUP_ENVTEST) use -p env); \
-		go test -v -count 1 -race ./controllers -ginkgo.progress -ginkgo.v -ginkgo.fail-fast
+		go test -v -count 1 -race ./controllers -ginkgo.show-node-events -ginkgo.v -ginkgo.fail-fast
 	source <($(SETUP_ENVTEST) use -p env); \
-		go test -v -count 1 -race ./hooks/... -ginkgo.progress -ginkgo.v
+		go test -v -count 1 -race ./hooks/... -ginkgo.show-node-events -ginkgo.v
 
 .PHONY: test
 test: test-tools

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -38,7 +38,7 @@ start: setup $(KUBECTL_ACCURATE)
 .PHONY: test
 test:
 	env PATH=$$(pwd)/../bin:$$PATH RUN_E2E=1 \
-		go test -v -race . -ginkgo.progress -ginkgo.v -ginkgo.fail-fast
+		go test -v -race . -ginkgo.show-node-events -ginkgo.v -ginkgo.fail-fast
 
 .PHONY: logs
 logs:


### PR DESCRIPTION
While debugging some failed tests, I noticed that we use a deprecated Ginkgo option. This PR fixes it with what I think would be equivalent functionality.

Warning when running tests:

````
--ginkgo.progress is deprecated .  The functionality provided by --progress was confusing and is no longer needed.  Use --show-node-events instead to see node entry and exit events included in the timeline of failed and verbose specs.  Or you can run with -vv to always see all node events.  Lastly, --poll-progress-after and the PollProgressAfter decorator now provide a better mechanism for debugging specs that tend to get stuck
````