### PR TITLE
Fix Renovate authentication with GitHub App token

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@13da59cf7cfbd3bfea72ce26752ed22edf747ce9 # renovate v43.0.2
+        uses: renovatebot/github-action@7876d7a812254599d262d62b6b2c2706018258a2 # renovate v43.0.10
         with:
           configurationFile: renovate.json
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -2,14 +2,23 @@ name: Renovate
 on:
   schedule:
     - cron: '0 10 * * 1'
+  workflow_dispatch:
 jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@13da59cf7cfbd3bfea72ce26752ed22edf747ce9 # renovate v43.0.2
         with:
           configurationFile: renovate.json
-          token: ${{ secrets.RENOVATE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
### Overview
<!-- Write a summary of the content in one line -->
- Resolved #166 
- Fix Renovate authentication by implementing GitHub App token-based setup as discussed in issue.

### What
<!-- List the content you worked on in bullet points -->
- Implemented GitHub App token authentication for Renovate workflow
- Added `actions/create-github-app-token@v2` action to generate short-lived tokens
- Updated Renovate GitHub Action to use the generated app token
- Configured workflow to run on schedule (weekly on Monday at 10:00 UTC) and manual dispatch

### Why
<!-- Explain the background to why you needed to do this PR 
It would be good if you could summarize it here so that it is complete without relying on other apps or related information -->
Renovate was previously not working due to token authentication errors. 
We decided to continue using Renovate instead of switching to Dependabot because: 

- Renovate has more features compared to Dependabot
- Aqua dependencies can only be updated with Renovate
- GitHub App tokens provide better security than PATs (Personal Access Tokens) as they are short-lived and have limited scope
- This approach allows CI to be triggered on Renovate PRs, unlike using GITHUB_TOKEN

### Ref
<!-- Include any related information such as work memos or official documentation -->
When this CI is executed, the following dashboard is expected to be generated.
- #174 