### PR TITLE
Introduce golangci-lint and remove standalone staticcheck

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,7 @@ jobs:
     - uses: ./.github/actions/aqua
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+    - run: make lint
     - run: make test
     - run: make check-generate
     - run: make envtest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,8 @@
+version: "2"
+linters:
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - (*text/tabwriter.Writer).Flush

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ CTRL_RUNTIME_VERSION := $(shell awk '/sigs.k8s.io\/controller-runtime/ {print su
 
 # Test tools
 BIN_DIR := $(shell pwd)/bin
-GOLANGCI_LINT := $(BIN_DIR)/golangci-lint
 SUDO = sudo
 
 # Set the shell used to bash for better error handling.
@@ -100,12 +99,12 @@ envtest: setup-envtest
 		go test -v -count 1 -race ./hooks/... -ginkgo.show-node-events -ginkgo.v
 
 .PHONY: lint
-lint: tools
-	$(GOLANGCI_LINT) run ./... -v
+lint: setup
+	golangci-lint run ./... -v
 
 .PHONY: lint-fix
-lint-fix: tools
-	$(GOLANGCI_LINT) run ./... -v --fix
+lint-fix: setup
+	golangci-lint run ./... -v --fix
 
 .PHONY: test
 test: 
@@ -148,9 +147,3 @@ GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 }
 endef
 
-.PHONY: tools
-tools: $(GOLANGCI_LINT)
-
-$(GOLANGCI_LINT):
-	mkdir -p $(BIN_DIR)
-	GOBIN=$(BIN_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ CTRL_RUNTIME_VERSION := $(shell awk '/sigs.k8s.io\/controller-runtime/ {print su
 
 # Test tools
 BIN_DIR := $(shell pwd)/bin
-STATICCHECK := $(BIN_DIR)/staticcheck
 GOLANGCI_LINT := $(BIN_DIR)/golangci-lint
 SUDO = sudo
 
@@ -103,7 +102,6 @@ envtest: setup-envtest
 .PHONY: lint
 lint: tools
 	$(GOLANGCI_LINT) run ./... -v
-	$(STATICCHECK) ./...
 
 .PHONY: test
 test: 
@@ -147,11 +145,7 @@ GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 endef
 
 .PHONY: tools
-tools: $(STATICCHECK) $(GOLANGCI_LINT)
-
-$(STATICCHECK):
-	mkdir -p $(BIN_DIR)
-	GOBIN=$(BIN_DIR) go install honnef.co/go/tools/cmd/staticcheck@latest
+tools: $(GOLANGCI_LINT)
 
 $(GOLANGCI_LINT):
 	mkdir -p $(BIN_DIR)

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,10 @@ envtest: setup-envtest
 lint: tools
 	$(GOLANGCI_LINT) run ./... -v
 
+.PHONY: lint-fix
+lint-fix: tools
+	$(GOLANGCI_LINT) run ./... -v --fix
+
 .PHONY: test
 test: 
 	go test -v -count 1 -race ./api/... ./internal/... ./pkg/...
@@ -149,4 +153,4 @@ tools: $(GOLANGCI_LINT)
 
 $(GOLANGCI_LINT):
 	mkdir -p $(BIN_DIR)
-	GOBIN=$(BIN_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+	GOBIN=$(BIN_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CTRL_RUNTIME_VERSION := $(shell awk '/sigs.k8s.io\/controller-runtime/ {print su
 # Test tools
 BIN_DIR := $(shell pwd)/bin
 STATICCHECK := $(BIN_DIR)/staticcheck
+GOLANGCI_LINT := $(BIN_DIR)/golangci-lint
 SUDO = sudo
 
 # Set the shell used to bash for better error handling.
@@ -99,13 +100,17 @@ envtest: setup-envtest
 	source <($(SETUP_ENVTEST) use -p env); \
 		go test -v -count 1 -race ./hooks/... -ginkgo.show-node-events -ginkgo.v
 
+.PHONY: lint
+lint: tools
+	$(GOLANGCI_LINT) run ./... -v
+	$(STATICCHECK) ./...
+
 .PHONY: test
-test: test-tools
+test: 
 	go test -v -count 1 -race ./api/... ./internal/... ./pkg/...
 	go install ./...
 	go vet ./...
 	test -z $$(gofmt -s -l . | tee /dev/stderr)
-	$(STATICCHECK) ./...
 
 ##@ Build
 
@@ -141,9 +146,13 @@ GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 }
 endef
 
-.PHONY: test-tools
-test-tools: $(STATICCHECK)
+.PHONY: tools
+tools: $(STATICCHECK) $(GOLANGCI_LINT)
 
 $(STATICCHECK):
 	mkdir -p $(BIN_DIR)
 	GOBIN=$(BIN_DIR) go install honnef.co/go/tools/cmd/staticcheck@latest
+
+$(GOLANGCI_LINT):
+	mkdir -p $(BIN_DIR)
+	GOBIN=$(BIN_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -22,3 +22,4 @@ packages:
     registry: local
   - name: kubernetes/code-generator/conversion-gen@v0.35.0
     registry: local
+  - name: golangci/golangci-lint@v2.11.3

--- a/controllers/namespace_controller.go
+++ b/controllers/namespace_controller.go
@@ -261,7 +261,7 @@ func (r *NamespaceReconciler) propagateUpdate(ctx context.Context, res *unstruct
 		return err
 	}
 
-	if equality.Semantic.Equalities.DeepDerivative(c2, c) {
+	if equality.Semantic.DeepDerivative(c2, c) {
 		return nil
 	}
 

--- a/controllers/propagate.go
+++ b/controllers/propagate.go
@@ -143,7 +143,7 @@ func (r *PropagateController) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, err
 		}
 	case "":
-		//nolint:staticcheck
+		//nolint:staticcheck // SA1019: subject for removal
 		if !config.DefaultFeatureGate.Enabled(feature.DisablePropagateGenerated) && ann[constants.AnnGenerated] != notGenerated {
 			if err := r.checkController(ctx, obj); err != nil {
 				logger.Error(err, "failed to check the controller reference")
@@ -397,7 +397,7 @@ func (r *PropagateController) SetupWithManager(mgr ctrl.Manager) error {
 		if _, ok := ann[constants.AnnPropagate]; ok {
 			return true
 		}
-		//nolint:staticcheck
+		//nolint:staticcheck // SA1019: subject for removal
 		if config.DefaultFeatureGate.Enabled(feature.DisablePropagateGenerated) || ann[constants.AnnGenerated] == notGenerated {
 			return false
 		}

--- a/controllers/propagate.go
+++ b/controllers/propagate.go
@@ -144,7 +144,6 @@ func (r *PropagateController) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	case "":
 		//nolint:staticcheck
-		//lint:ignore SA1019 subject for removal
 		if !config.DefaultFeatureGate.Enabled(feature.DisablePropagateGenerated) && ann[constants.AnnGenerated] != notGenerated {
 			if err := r.checkController(ctx, obj); err != nil {
 				logger.Error(err, "failed to check the controller reference")
@@ -399,7 +398,6 @@ func (r *PropagateController) SetupWithManager(mgr ctrl.Manager) error {
 			return true
 		}
 		//nolint:staticcheck
-		//lint:ignore SA1019 subject for removal
 		if config.DefaultFeatureGate.Enabled(feature.DisablePropagateGenerated) || ann[constants.AnnGenerated] == notGenerated {
 			return false
 		}

--- a/controllers/propagate.go
+++ b/controllers/propagate.go
@@ -143,6 +143,7 @@ func (r *PropagateController) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, err
 		}
 	case "":
+		//nolint:staticcheck
 		//lint:ignore SA1019 subject for removal
 		if !config.DefaultFeatureGate.Enabled(feature.DisablePropagateGenerated) && ann[constants.AnnGenerated] != notGenerated {
 			if err := r.checkController(ctx, obj); err != nil {
@@ -397,6 +398,7 @@ func (r *PropagateController) SetupWithManager(mgr ctrl.Manager) error {
 		if _, ok := ann[constants.AnnPropagate]; ok {
 			return true
 		}
+		//nolint:staticcheck
 		//lint:ignore SA1019 subject for removal
 		if config.DefaultFeatureGate.Enabled(feature.DisablePropagateGenerated) || ann[constants.AnnGenerated] == notGenerated {
 			return false

--- a/controllers/propagate_test.go
+++ b/controllers/propagate_test.go
@@ -337,6 +337,7 @@ var _ = Describe("SubNamespace controller", func() {
 		cm1 := &corev1.ConfigMap{}
 		cm1.Namespace = rootNS
 		cm1.Name = "cm-generate"
+		//nolint:staticcheck
 		//lint:ignore SA1019 subject for removal
 		cm1.Annotations = map[string]string{constants.AnnPropagateGenerated: constants.PropagateUpdate}
 		cm1.Data = map[string]string{"foo": "bar"}
@@ -351,12 +352,13 @@ var _ = Describe("SubNamespace controller", func() {
 		svc1 := &corev1.Service{}
 		svc1.Namespace = rootNS
 		svc1.Name = "svc1"
-		ctrl.SetControllerReference(cm1, svc1, scheme)
+		Expect(ctrl.SetControllerReference(cm1, svc1, scheme)).To(Succeed())
 		svc1.Spec.ClusterIP = "None"
 		svc1.Spec.Ports = []corev1.ServicePort{{Port: 3333, TargetPort: intstr.FromInt32(3333)}}
 		Expect(k8sClient.Create(ctx, svc1)).To(Succeed())
 
 		Eventually(komega.Object(svc1)).Should(HaveField("Annotations", HaveKeyWithValue(constants.AnnPropagate, constants.PropagateUpdate)))
+		//nolint:staticcheck
 		//lint:ignore SA1019 subject for removal
 		Expect(svc1.Annotations).NotTo(HaveKey(constants.AnnGenerated))
 
@@ -368,6 +370,7 @@ var _ = Describe("SubNamespace controller", func() {
 		svc2.Spec.Ports = []corev1.ServicePort{{Port: 3333, TargetPort: intstr.FromInt32(3333)}}
 		Expect(k8sClient.Create(ctx, svc2)).To(Succeed())
 
+		//nolint:staticcheck
 		//lint:ignore SA1019 subject for removal
 		Eventually(komega.Object(svc2)).Should(HaveField("Annotations", HaveKeyWithValue(constants.AnnGenerated, notGenerated)))
 	})

--- a/controllers/propagate_test.go
+++ b/controllers/propagate_test.go
@@ -337,7 +337,7 @@ var _ = Describe("SubNamespace controller", func() {
 		cm1 := &corev1.ConfigMap{}
 		cm1.Namespace = rootNS
 		cm1.Name = "cm-generate"
-		//nolint:staticcheck
+		//nolint:staticcheck // SA1019: subject for removal
 		cm1.Annotations = map[string]string{constants.AnnPropagateGenerated: constants.PropagateUpdate}
 		cm1.Data = map[string]string{"foo": "bar"}
 		Expect(k8sClient.Create(ctx, cm1)).To(Succeed())
@@ -357,7 +357,7 @@ var _ = Describe("SubNamespace controller", func() {
 		Expect(k8sClient.Create(ctx, svc1)).To(Succeed())
 
 		Eventually(komega.Object(svc1)).Should(HaveField("Annotations", HaveKeyWithValue(constants.AnnPropagate, constants.PropagateUpdate)))
-		//nolint:staticcheck
+		//nolint:staticcheck // SA1019: subject for removal
 		Expect(svc1.Annotations).NotTo(HaveKey(constants.AnnGenerated))
 
 		svc2 := &corev1.Service{}
@@ -368,7 +368,7 @@ var _ = Describe("SubNamespace controller", func() {
 		svc2.Spec.Ports = []corev1.ServicePort{{Port: 3333, TargetPort: intstr.FromInt32(3333)}}
 		Expect(k8sClient.Create(ctx, svc2)).To(Succeed())
 
-		//nolint:staticcheck
+		//nolint:staticcheck // SA1019: subject for removal
 		Eventually(komega.Object(svc2)).Should(HaveField("Annotations", HaveKeyWithValue(constants.AnnGenerated, notGenerated)))
 	})
 })

--- a/controllers/propagate_test.go
+++ b/controllers/propagate_test.go
@@ -338,7 +338,6 @@ var _ = Describe("SubNamespace controller", func() {
 		cm1.Namespace = rootNS
 		cm1.Name = "cm-generate"
 		//nolint:staticcheck
-		//lint:ignore SA1019 subject for removal
 		cm1.Annotations = map[string]string{constants.AnnPropagateGenerated: constants.PropagateUpdate}
 		cm1.Data = map[string]string{"foo": "bar"}
 		Expect(k8sClient.Create(ctx, cm1)).To(Succeed())
@@ -359,7 +358,6 @@ var _ = Describe("SubNamespace controller", func() {
 
 		Eventually(komega.Object(svc1)).Should(HaveField("Annotations", HaveKeyWithValue(constants.AnnPropagate, constants.PropagateUpdate)))
 		//nolint:staticcheck
-		//lint:ignore SA1019 subject for removal
 		Expect(svc1.Annotations).NotTo(HaveKey(constants.AnnGenerated))
 
 		svc2 := &corev1.Service{}
@@ -371,7 +369,6 @@ var _ = Describe("SubNamespace controller", func() {
 		Expect(k8sClient.Create(ctx, svc2)).To(Succeed())
 
 		//nolint:staticcheck
-		//lint:ignore SA1019 subject for removal
 		Eventually(komega.Object(svc2)).Should(HaveField("Annotations", HaveKeyWithValue(constants.AnnGenerated, notGenerated)))
 	})
 })

--- a/hooks/allow-cascade-delete/suite_test.go
+++ b/hooks/allow-cascade-delete/suite_test.go
@@ -123,7 +123,7 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
-		conn.Close()
+		Expect(conn.Close()).To(Succeed())
 		return nil
 	}).Should(Succeed())
 

--- a/hooks/suite_test.go
+++ b/hooks/suite_test.go
@@ -157,7 +157,7 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
-		conn.Close()
+		Expect(conn.Close()).To(Succeed())
 		return nil
 	}).Should(Succeed())
 

--- a/pkg/config/types_test.go
+++ b/pkg/config/types_test.go
@@ -227,7 +227,7 @@ func TestValidate(t *testing.T) {
 
 func newFakeRESTMapper() meta.RESTMapper {
 	cs := &fakeclientset.Clientset{}
-	cs.Fake.Resources = append(cs.Fake.Resources, &metav1.APIResourceList{
+	cs.Resources = append(cs.Resources, &metav1.APIResourceList{
 		GroupVersion: "v1",
 		APIResources: []metav1.APIResource{
 			{Name: "secrets", Namespaced: true, Kind: "Secret"},

--- a/renovate.json5
+++ b/renovate.json5
@@ -199,6 +199,15 @@
         'renovatebot/github-action',
       ],
     },
+    {
+      "description": "Enable golangci-lint in aqua.yaml",
+      "enabled": true,
+      "matchDatasources": ["github-tags"],
+      "matchDepNames": ["golangci/golangci-lint"],
+      "matchFileNames": [
+        "aqua.yaml",
+      ],
+    },
   ],
   postUpdateOptions: [
     'gomodTidy',


### PR DESCRIPTION
This PR introduces golangci-lint to the repository.

Changes:

- Add golangci-lint configuration
- Fix existing lint issues
- Remove the standalone staticcheck step, since staticcheck is already included in golangci-lint's default linters

Fixes #171