### PR TITLE
Remove obsolete SSA migration code

### DIFF
--- a/controllers/namespace_controller.go
+++ b/controllers/namespace_controller.go
@@ -125,12 +125,6 @@ func (r *NamespaceReconciler) propagateMeta(ctx context.Context, ns, parent *cor
 		labels[constants.LabelParent] = parent.Name
 	}
 
-	// Ensure that managed fields are upgraded to SSA before the following SSA.
-	// TODO(migration): This code could be removed after a couple of releases.
-	if err := upgradeManagedFields(ctx, r.Client, ns); err != nil {
-		return err
-	}
-
 	ac := corev1ac.Namespace(ns.Name).
 		WithLabels(labels).
 		WithAnnotations(annotations)
@@ -254,12 +248,6 @@ func (r *NamespaceReconciler) propagateUpdate(ctx context.Context, res *unstruct
 	}
 
 	c2 := r.cloneResource(res, ns)
-
-	// Ensure that managed fields are upgraded to SSA before the following SSA.
-	// TODO(migration): This code could be removed after a couple of releases.
-	if err := upgradeManagedFields(ctx, r.Client, c2); err != nil {
-		return err
-	}
 
 	if equality.Semantic.DeepDerivative(c2, c) {
 		return nil

--- a/controllers/namespace_controller_test.go
+++ b/controllers/namespace_controller_test.go
@@ -482,28 +482,6 @@ var _ = Describe("Namespace controller", func() {
 		))
 	})
 
-	It("should remove sub namespace labels/annotations set pre SSA migration", func() {
-		ns := &corev1.Namespace{}
-		ns.Name = "pre-ssa-child"
-		Expect(komega.Get(ns)()).To(Succeed())
-		Expect(ns.Labels).To(HaveKeyWithValue("bar.glob/l", "delete-me"))
-		Expect(ns.Annotations).To(HaveKeyWithValue("bar.glob/a", "delete-me"))
-		sn := &accuratev2.SubNamespace{}
-		sn.Name = "pre-ssa-child"
-		sn.Namespace = "pre-ssa-root"
-		Expect(komega.Update(sn, func() {
-			delete(sn.Spec.Labels, "bar.glob/l")
-			delete(sn.Spec.Annotations, "bar.glob/a")
-		})()).To(Succeed())
-
-		Eventually(komega.Object(ns)).Should(And(
-			HaveField("Labels", Not(HaveKey("bar.glob/l"))),
-			HaveField("Annotations", Not(HaveKey("bar.glob/a"))),
-		))
-		Expect(ns.Labels).To(HaveKeyWithValue("foo.glob/l", "glob"))
-		Expect(ns.Annotations).To(HaveKeyWithValue("foo.glob/a", "glob"))
-	})
-
 	Context("templated namespace", func() {
 		var ns1 *corev1.Namespace
 

--- a/controllers/propagate.go
+++ b/controllers/propagate.go
@@ -283,12 +283,6 @@ func (r *PropagateController) propagateUpdate(ctx context.Context, obj, parent *
 	if parent != nil {
 		clone := r.cloneResource(parent, obj.GetNamespace())
 
-		// Ensure that managed fields are upgraded to SSA before the following SSA.
-		// TODO(migration): This code could be removed after a couple of releases.
-		if err := upgradeManagedFields(ctx, r.Client, clone); err != nil {
-			return err
-		}
-
 		if !equality.Semantic.DeepDerivative(clone, obj) {
 			ac := client.ApplyConfigurationFromUnstructured(clone)
 			if err := r.Apply(ctx, ac, fieldOwner, client.ForceOwnership); err != nil {
@@ -326,12 +320,6 @@ func (r *PropagateController) propagateUpdate(ctx context.Context, obj, parent *
 		}
 
 		clone := r.cloneResource(obj, child.Name)
-
-		// Ensure that managed fields are upgraded to SSA before the following SSA.
-		// TODO(migration): This code could be removed after a couple of releases.
-		if err := upgradeManagedFields(ctx, r.Client, clone); err != nil {
-			return err
-		}
 
 		if equality.Semantic.DeepDerivative(clone, cres) {
 			continue

--- a/controllers/ssa_client.go
+++ b/controllers/ssa_client.go
@@ -1,31 +1,9 @@
 package controllers
 
 import (
-	"context"
-
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/util/csaupgrade"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
 	fieldOwner client.FieldOwner = "accurate-controller"
 )
-
-// TODO(migration): This code could be removed after a couple of releases.
-// upgradeManagedFields is a migration function that migrates the ownership of
-// fields from the Update operation to the Apply operation. This is required
-// to ensure that the apply operations will also remove fields that were
-// set by the Update operation.
-func upgradeManagedFields(ctx context.Context, c client.Client, obj client.Object, opts ...csaupgrade.Option) error {
-	patch, err := csaupgrade.UpgradeManagedFieldsPatch(obj, sets.New(string(fieldOwner)), string(fieldOwner), opts...)
-	if err != nil {
-		return err
-	}
-	if patch != nil {
-		return c.Patch(ctx, obj, client.RawPatch(types.JSONPatchType, patch))
-	}
-	// No work to be done - already upgraded
-	return nil
-}

--- a/controllers/subnamespace_controller.go
+++ b/controllers/subnamespace_controller.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
-	"k8s.io/client-go/util/csaupgrade"
 	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -155,12 +154,6 @@ func (r *SubNamespaceReconciler) reconcileNS(ctx context.Context, sn *accuratev2
 					WithMessage("Conflicting namespace already exists"),
 			),
 		)
-	}
-
-	// Ensure that status managed fields are upgraded to SSA before the following SSA.
-	// TODO(migration): This code could be removed after a couple of releases.
-	if err := upgradeManagedFields(ctx, r.Client, sn, csaupgrade.Subresource("status")); err != nil {
-		return err
 	}
 
 	return r.Status().Apply(ctx, ac, fieldOwner, client.ForceOwnership)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"maps"
 	"path/filepath"
 	"testing"
 	"time"
@@ -116,34 +115,6 @@ var _ = BeforeSuite(func() {
 	ns.Name = "prop-instance"
 	ns.Labels = map[string]string{constants.LabelTemplate: "prop-tmpl"}
 	Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
-
-	// Create resources as they would look like before migration to SSA
-	ns = &corev1.Namespace{}
-	ns.Name = "pre-ssa-root"
-	ns.Labels = map[string]string{constants.LabelType: constants.NSTypeRoot}
-	Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
-
-	sn := &accuratev2.SubNamespace{}
-	sn.Name = "pre-ssa-child"
-	sn.Namespace = "pre-ssa-root"
-	sn.Spec.Labels = map[string]string{
-		"foo.glob/l": "glob",
-		"bar.glob/l": "delete-me",
-	}
-	sn.Spec.Annotations = map[string]string{
-		"foo.glob/a": "glob",
-		"bar.glob/a": "delete-me",
-	}
-	Expect(k8sClient.Create(context.Background(), sn)).To(Succeed())
-
-	ns = &corev1.Namespace{}
-	ns.Name = sn.Name
-	ns.Finalizers = []string{constants.Finalizer}
-	ns.Labels = map[string]string{constants.LabelCreatedBy: constants.CreatedBy, constants.LabelParent: sn.Namespace}
-	maps.Copy(ns.Labels, sn.Spec.Labels)
-	ns.Annotations = sn.Spec.Annotations
-	// Setting accurate-controller as field owner to simulate existing resource created by Accurate
-	Expect(k8sClient.Create(context.Background(), ns, fieldOwner)).To(Succeed())
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
We migrated this operator to use server-side apply (SSA) a long time ago, so I think it's time to remove the code related to upgrading from CSA to SSA.

Relates to https://github.com/cybozu-go/accurate/issues/173.