### PR TITLE
Make apiserver-qps-throttle only apply when set

### DIFF
--- a/cmd/accurate-controller/sub/root.go
+++ b/cmd/accurate-controller/sub/root.go
@@ -17,7 +17,6 @@ import (
 
 const (
 	defaultConfigPath = "/etc/accurate/config.yaml"
-	defaultQPS        = 50
 )
 
 var options struct {
@@ -74,7 +73,7 @@ func init() {
 	fs.StringVar(&options.leaderElectionID, "leader-election-id", "accurate", "ID for leader election by controller-runtime")
 	fs.StringVar(&options.webhookAddr, "webhook-addr", ":9443", "Listen address for the webhook endpoint")
 	fs.StringVar(&options.certDir, "cert-dir", "", "webhook certificate directory")
-	fs.IntVar(&options.qps, "apiserver-qps-throttle", defaultQPS, "The maximum QPS to the API server.")
+	fs.IntVar(&options.qps, "apiserver-qps-throttle", 0, "Maximum client-side QPS to the API server. Values greater than 0 enable throttling.")
 
 	fs.BoolVar(&options.webhookAllowCascadingDeletion, "webhook-allow-cascading-deletion", false, "Set to true to allow cascading deletion of namespaces (namespaces with children)")
 

--- a/cmd/accurate-controller/sub/run.go
+++ b/cmd/accurate-controller/sub/run.go
@@ -62,8 +62,10 @@ func subMain(ns, addr string, port int) error {
 	if err != nil {
 		return fmt.Errorf("failed to get REST config: %w", err)
 	}
-	restCfg.QPS = float32(options.qps)
-	restCfg.Burst = int(restCfg.QPS * 1.5)
+	if options.qps > 0 {
+		restCfg.QPS = float32(options.qps)
+		restCfg.Burst = int(restCfg.QPS * 1.5)
+	}
 
 	mgr, err := ctrl.NewManager(restCfg, ctrl.Options{
 		Scheme: scheme,

--- a/docs/accurate-controller.md
+++ b/docs/accurate-controller.md
@@ -55,29 +55,36 @@ watches:
 
 ```txt
 Flags:
-      --add_dir_header                   If true, adds the file directory to the header
-      --alsologtostderr                  log to standard error as well as files
-      --apiserver-qps-throttle int       The maximum QPS to the API server. (default 50)
-      --cert-dir string                  webhook certificate directory
-      --config-file string               Configuration file path (default "/etc/accurate/config.yaml")
-      --health-probe-addr string         Listen address for health probes (default ":8081")
-  -h, --help                             help for accurate-controller
-      --leader-election-id string        ID for leader election by controller-runtime (default "accurate")
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory
-      --log_file string                  If non-empty, use this log file
-      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --metrics-addr string              The address the metric endpoint binds to (default ":8080")
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files
-      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --version                          version for accurate-controller
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
-      --webhook-addr string              Listen address for the webhook endpoint (default ":9443")
-      --zap-devel                        Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error)
-      --zap-encoder encoder              Zap log encoding (one of 'json' or 'console')
-      --zap-log-level level              Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
-      --zap-stacktrace-level level       Zap Level at and above which stacktraces are captured (one of 'info', 'error', 'panic').
+      --add_dir_header                     If true, adds the file directory to the header of the log messages
+      --alsologtostderr                    log to standard error as well as files (no effect when -logtostderr=true)
+      --apiserver-qps-throttle int         Maximum client-side QPS to the API server. Values greater than 0 enable throttling.
+      --cert-dir string                    webhook certificate directory
+      --config-file string                 Configuration file path (default "/etc/accurate/config.yaml")
+      --feature-gates mapStringBool        A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
+                                           AllAlpha=true|false (ALPHA - default=false)
+                                           AllBeta=true|false (BETA - default=false)
+                                           DisablePropagateGenerated=true|false (BETA - default=true)
+      --health-probe-addr string           Listen address for health probes (default ":8081")
+  -h, --help                               help for accurate-controller
+      --leader-election-id string          ID for leader election by controller-runtime (default "accurate")
+      --log_backtrace_at traceLocation     when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                     If non-empty, write log files in this directory (no effect when -logtostderr=true)
+      --log_file string                    If non-empty, use this log file (no effect when -logtostderr=true)
+      --log_file_max_size uint             Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                        log to standard error instead of files (default true)
+      --metrics-addr string                The address the metric endpoint binds to (default ":8080")
+      --one_output                         If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
+      --skip_headers                       If true, avoid header prefixes in the log messages
+      --skip_log_headers                   If true, avoid headers when opening log files (no effect when -logtostderr=true)
+      --stderrthreshold severity           logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true) (default 2)
+  -v, --v Level                            number for the log level verbosity
+      --version                            version for accurate-controller
+      --vmodule moduleSpec                 comma-separated list of pattern=N settings for file-filtered logging
+      --webhook-addr string                Listen address for the webhook endpoint (default ":9443")
+      --webhook-allow-cascading-deletion   Set to true to allow cascading deletion of namespaces (namespaces with children)
+      --zap-devel                          Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error)
+      --zap-encoder encoder                Zap log encoding (one of 'json' or 'console')
+      --zap-log-level level                Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
+      --zap-stacktrace-level level         Zap Level at and above which stacktraces are captured (one of 'info', 'error', 'panic').
+      --zap-time-encoding time-encoding    Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'). Defaults to 'epoch'.
 ```


### PR DESCRIPTION
This slightly changes the behavior of the `apiserver-qps-throttle` flag, so that only when it's set (>0) it will be forwarded to controller-runtime. In newer releases of controller-runtime, the default has been changed to disable client-side rate limiting in favour of the server-side API priority and fairness.

This solution was proposed by @zoetrope in https://github.com/cybozu-go/accurate/issues/165#issuecomment-3055774779.

It seems like the flags documentation was a bit outdated, but I don't think it harms to refresh it completely, and not only change what is changed in this PR.

Fixes https://github.com/cybozu-go/accurate/issues/165

Relates to https://github.com/cybozu-go/accurate/issues/173