### PR TITLE
Update renovate config to stop scheduled trigger

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,7 +1,5 @@
 name: Renovate
 on:
-  schedule:
-    - cron: '0 10 * * 1'
   workflow_dispatch:
 jobs:
   renovate:

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -13,5 +13,5 @@ If Kubernetes or controller-runtime API has changed, please fix the relevant sou
 
 ## How to update dependencies
 
-Renovate will create PRs that update dependencies once a week.
+Renovate will create PRs that update dependencies when you [trigger the workflow with `workflow_dispatch`](https://github.com/cybozu-go/accurate/actions/workflows/renovate.yaml).
 However, Kubernetes is only updated with patched versions.


### PR DESCRIPTION
Stop scheduled trigger for renovate to avoid running GitHub Actions workflows at arbitrary times for security reasons.

## Changes

- Remove scheduled trigger (cron) from Renovate workflow.
    - `workflow_dispatch` trigger is still allowed for manual execution. 