### PR TITLE
clarify permissions on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - 'main'
+permissions:
+  contents: read
 jobs:
   build:
     name: Build binaries

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -6,6 +6,9 @@ on:
       - "charts/**"
       - '!**.md'
 
+permissions:
+  contents: read
+
 jobs:
   lint-test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/mdbook.yaml
+++ b/.github/workflows/mdbook.yaml
@@ -8,6 +8,8 @@ jobs:
   build:
     name: Build book
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: ./.github/actions/aqua
@@ -23,6 +25,8 @@ jobs:
     name: Publish book on GitHub Pages
     runs-on: ubuntu-24.04
     needs: build
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,9 @@ jobs:
   image:
     name: Push Container Image
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup
@@ -26,6 +29,8 @@ jobs:
     name: Release on GitHub
     needs: image
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -49,6 +54,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: release
     if: contains(needs.release.result, 'success')
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,6 +1,8 @@
 name: Renovate
 on:
   workflow_dispatch:
+# No permissions are required for this workflow because the GitHub App has its own permissions.
+permissions: {}
 jobs:
   renovate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As part of our efforts to strengthen security, our team is implementing a policy to set the default authentication token permissions for GitHub Actions to read-only.

To accommodate this, workflows that require additional permissions must explicitly declare them.

After this change is merged, we plan to restrict the default permissions to read-only via the repository settings.