### PR TITLE
fix: add SHA256 checksum verification for cert-manager manifest

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -54,13 +54,17 @@ jobs:
           registry_port: 5000
       - name: Apply cert-manager
         env:
-          # renovate: datasource=github-releases depName=cert-manager/cert-manager
+          # renovate: datasource=helm registryUrl=https://charts.jetstack.io depName=cert-manager
           CERT_MANAGER_VERSION: v1.20.2
-          CERT_MANAGER_SHA256: 1ce11cae912adecc69e6bb623435fafc9ed21505f9efff98bd71d7b80f01db1f
+          CERT_MANAGER_GPG_KEY_URL: https://cert-manager.io/public-keys/cert-manager-keyring-2021-09-20-1020CF3C033D4F35BAE1C19E1226061C665DF13E.gpg
         run: |
-          curl -fsSL -o cert-manager.yaml https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
-          echo "${CERT_MANAGER_SHA256}  cert-manager.yaml" | sha256sum --check
-          kubectl apply -f cert-manager.yaml
+          curl -fsSL -o cert-manager-keyring.gpg "${CERT_MANAGER_GPG_KEY_URL}"
+          helm pull oci://quay.io/jetstack/charts/cert-manager \
+            --version "${CERT_MANAGER_VERSION}" \
+            --verify --keyring cert-manager-keyring.gpg \
+            --untar --untardir ./cert-manager-chart
+          helm install cert-manager ./cert-manager-chart/cert-manager \
+            --namespace cert-manager --create-namespace --set crds.enabled=true
           kubectl -n cert-manager wait --for=condition=available --timeout=180s --all deployments
       - name: Prepare values.yaml
         run: |

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -53,8 +53,14 @@ jobs:
           registry_name: kind-registry
           registry_port: 5000
       - name: Apply cert-manager
+        env:
+          # renovate: datasource=github-releases depName=cert-manager/cert-manager
+          CERT_MANAGER_VERSION: v1.20.2
+          CERT_MANAGER_SHA256: 1ce11cae912adecc69e6bb623435fafc9ed21505f9efff98bd71d7b80f01db1f
         run: |
-          kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
+          curl -fsSL -o cert-manager.yaml https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
+          echo "${CERT_MANAGER_SHA256}  cert-manager.yaml" | sha256sum --check
+          kubectl apply -f cert-manager.yaml
           kubectl -n cert-manager wait --for=condition=available --timeout=180s --all deployments
       - name: Prepare values.yaml
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 /dist
 
 # Generated files
+/tmp-charts
 /docs/book
 
 /vendor

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Run and try Accurate on a [kind (Kubernetes-In-Docker)][kind] cluster as follows
 3. Install [aqua][].
 
     ```bash
-    go install github.com/aquaproj/aqua/v2/cmd/aqua@latest
+    go install github.com/aquaproj/aqua/v2/cmd/aqua@v2.53.3
     ```
 
     cf. <https://aquaproj.github.io/docs/install>

--- a/charts/accurate/README.md
+++ b/charts/accurate/README.md
@@ -15,12 +15,15 @@ helm repo update
 
 ```bash
 CERT_MANAGER_VERSION=v1.20.2
-CERT_MANAGER_SHA256=1ce11cae912adecc69e6bb623435fafc9ed21505f9efff98bd71d7b80f01db1f
-curl -fsSL -o cert-manager.yaml \
-	https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
-echo "${CERT_MANAGER_SHA256}  cert-manager.yaml" | sha256sum --check
-kubectl apply -f cert-manager.yaml
-rm -f cert-manager.yaml
+CERT_MANAGER_GPG_KEY_URL=https://cert-manager.io/public-keys/cert-manager-keyring-2021-09-20-1020CF3C033D4F35BAE1C19E1226061C665DF13E.gpg
+curl -fsSL -o cert-manager-keyring.gpg "${CERT_MANAGER_GPG_KEY_URL}"
+helm pull oci://quay.io/jetstack/charts/cert-manager \
+  --version "${CERT_MANAGER_VERSION}" \
+  --verify --keyring cert-manager-keyring.gpg \
+  --untar --untardir ./cert-manager-chart
+helm install cert-manager ./cert-manager-chart/cert-manager \
+  --namespace cert-manager --create-namespace --set crds.enabled=true
+rm -rf cert-manager-keyring.gpg ./cert-manager-chart
 ```
 
 ### Installing CustomResourceDefinitions (optional)

--- a/charts/accurate/README.md
+++ b/charts/accurate/README.md
@@ -14,7 +14,13 @@ helm repo update
 ### Installing cert-manager
 
 ```bash
-curl -fsL https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml | kubectl apply -f -
+CERT_MANAGER_VERSION=v1.20.2
+CERT_MANAGER_SHA256=1ce11cae912adecc69e6bb623435fafc9ed21505f9efff98bd71d7b80f01db1f
+curl -fsSL -o cert-manager.yaml \
+	https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
+echo "${CERT_MANAGER_SHA256}  cert-manager.yaml" | sha256sum --check
+kubectl apply -f cert-manager.yaml
+rm -f cert-manager.yaml
 ```
 
 ### Installing CustomResourceDefinitions (optional)

--- a/docs/install-plugin.md
+++ b/docs/install-plugin.md
@@ -50,13 +50,14 @@ kubectl krew install accurate
     The following is an example to install the plugin in `/usr/local/bin`.
 
     ```bash
-    curl -fsSL -o /tmp/kubectl-accurate.tar.gz \
-      https://github.com/cybozu-go/accurate/releases/download/${VERSION}/kubectl-accurate_${VERSION}_${OS}_${ARCH}.tar.gz
-    curl -fsSL -o /tmp/kubectl-accurate-checksums.txt \
-      https://github.com/cybozu-go/accurate/releases/download/${VERSION}/checksums.txt
-    cd /tmp && sha256sum --check --ignore-missing kubectl-accurate-checksums.txt
-    tar xz -C /usr/local/bin kubectl-accurate < /tmp/kubectl-accurate.tar.gz
-    rm /tmp/kubectl-accurate.tar.gz /tmp/kubectl-accurate-checksums.txt
+    BINARY=kubectl-accurate_${VERSION}_${OS}_${ARCH}.tar.gz
+    curl -fsSL -o /tmp/${BINARY} \
+      https://github.com/cybozu-go/accurate/releases/download/${VERSION}/${BINARY}
+    curl -fsSL https://github.com/cybozu-go/accurate/releases/download/${VERSION}/checksums.txt \
+      | grep "${BINARY}" > /tmp/${BINARY}.sha256
+    cd /tmp && sha256sum --check /tmp/${BINARY}.sha256
+    tar xz -C /usr/local/bin kubectl-accurate < /tmp/${BINARY}
+    rm /tmp/${BINARY} /tmp/${BINARY}.sha256
     ```
 
 5. Check the installation

--- a/docs/install-plugin.md
+++ b/docs/install-plugin.md
@@ -45,13 +45,18 @@ kubectl krew install accurate
    VERSION=< The version you want to install >
    ```
 
-4. Download the binary and put it in a directory of your `PATH`.
+4. Download the binary, verify the checksum, and put it in a directory of your `PATH`.
 
     The following is an example to install the plugin in `/usr/local/bin`.
 
     ```bash
-    curl -L -sS https://github.com/cybozu-go/accurate/releases/download/$(VERSION)/kubectl-accurate_$(VERSION)_$(OS)_$(ARCH).tar.gz \
-      | tar xz -C /usr/local/bin kubectl-accurate
+    curl -fsSL -o /tmp/kubectl-accurate.tar.gz \
+      https://github.com/cybozu-go/accurate/releases/download/${VERSION}/kubectl-accurate_${VERSION}_${OS}_${ARCH}.tar.gz
+    curl -fsSL -o /tmp/kubectl-accurate-checksums.txt \
+      https://github.com/cybozu-go/accurate/releases/download/${VERSION}/checksums.txt
+    cd /tmp && sha256sum --check --ignore-missing kubectl-accurate-checksums.txt
+    tar xz -C /usr/local/bin kubectl-accurate < /tmp/kubectl-accurate.tar.gz
+    rm /tmp/kubectl-accurate.tar.gz /tmp/kubectl-accurate-checksums.txt
     ```
 
 5. Check the installation

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -6,8 +6,12 @@
     If cert-manager is not installed on your cluster, install it as follows:
 
     ```bash
-    curl -fsLO https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
+    CERT_MANAGER_VERSION=v1.20.2
+    CERT_MANAGER_SHA256=1ce11cae912adecc69e6bb623435fafc9ed21505f9efff98bd71d7b80f01db1f
+    curl -fsSLO https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
+    echo "${CERT_MANAGER_SHA256}  cert-manager.yaml" | sha256sum --check
     kubectl apply -f cert-manager.yaml
+    rm -f cert-manager.yaml
     ```
 
 2. Setup Accurate Helm repository

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -7,11 +7,15 @@
 
     ```bash
     CERT_MANAGER_VERSION=v1.20.2
-    CERT_MANAGER_SHA256=1ce11cae912adecc69e6bb623435fafc9ed21505f9efff98bd71d7b80f01db1f
-    curl -fsSLO https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
-    echo "${CERT_MANAGER_SHA256}  cert-manager.yaml" | sha256sum --check
-    kubectl apply -f cert-manager.yaml
-    rm -f cert-manager.yaml
+    CERT_MANAGER_GPG_KEY_URL=https://cert-manager.io/public-keys/cert-manager-keyring-2021-09-20-1020CF3C033D4F35BAE1C19E1226061C665DF13E.gpg
+    curl -fsSL -o cert-manager-keyring.gpg "${CERT_MANAGER_GPG_KEY_URL}"
+    helm pull oci://quay.io/jetstack/charts/cert-manager \
+      --version "${CERT_MANAGER_VERSION}" \
+      --verify --keyring cert-manager-keyring.gpg \
+      --untar --untardir ./cert-manager-chart
+    helm install cert-manager ./cert-manager-chart/cert-manager \
+      --namespace cert-manager --create-namespace --set crds.enabled=true
+    rm -rf cert-manager-keyring.gpg ./cert-manager-chart
     ```
 
 2. Setup Accurate Helm repository

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,7 +1,10 @@
 KUBERNETES_VERSION = v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661 # renovate: kindest/node
-# renovate: datasource=github-releases depName=cert-manager/cert-manager
+# renovate: datasource=helm registryUrl=https://charts.jetstack.io depName=cert-manager
 CERT_MANAGER_VERSION = v1.20.2
-CERT_MANAGER_SHA256 = 1ce11cae912adecc69e6bb623435fafc9ed21505f9efff98bd71d7b80f01db1f
+CERT_MANAGER_GPG_KEY_URL = https://cert-manager.io/public-keys/cert-manager-keyring-2021-09-20-1020CF3C033D4F35BAE1C19E1226061C665DF13E.gpg
+
+PROJECT_DIR := $(CURDIR)/../
+CHART_DIR := $(PROJECT_DIR)/tmp-charts
 
 KUBECTL_ACCURATE := $(dir $(shell pwd))/bin/kubectl-accurate
 KUBECONFIG := $(shell pwd)/.kubeconfig
@@ -21,14 +24,12 @@ help:
 	@echo "stop       Stop the kind cluster"
 
 .PHONY: start
-start: setup $(KUBECTL_ACCURATE)
+start: setup $(KUBECTL_ACCURATE) $(CHART_DIR)/cert-manager/Chart.yaml
 	kind create cluster --name=accurate --config=$(KIND_CONFIG) --image=kindest/node:$(KUBERNETES_VERSION) --wait 1m
 	cd ..; docker build --no-cache -t accurate:dev .
 	kind load docker-image accurate:dev --name=accurate
-	curl -fsSL -o cert-manager.yaml https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml
-	echo "$(CERT_MANAGER_SHA256)  cert-manager.yaml" | sha256sum --check
-	kubectl apply -f cert-manager.yaml
-	rm -f cert-manager.yaml
+	helm install cert-manager $(CHART_DIR)/cert-manager \
+		--namespace cert-manager --create-namespace --set crds.enabled=true
 	kubectl -n cert-manager wait --for=condition=available --timeout=180s --all deployments
 	helm install --create-namespace --namespace accurate accurate ../charts/accurate -f values.yaml
 	kubectl -n accurate wait --for=condition=available --timeout=180s --all deployments
@@ -62,6 +63,18 @@ stop: setup
 $(KUBECTL_ACCURATE): $(wildcard ../cmd/kubectl-accurate/*/*.go)
 	mkdir -p ../bin
 	cd ..; GOBIN=$$(pwd)/bin go install ./cmd/kubectl-accurate
+
+$(CHART_DIR):
+	mkdir -p $(CHART_DIR)
+
+$(CHART_DIR)/cert-manager-keyring.gpg: | $(CHART_DIR)
+	curl -fsSL -o $(CHART_DIR)/cert-manager-keyring.gpg $(CERT_MANAGER_GPG_KEY_URL)
+
+$(CHART_DIR)/cert-manager/Chart.yaml: $(CHART_DIR)/cert-manager-keyring.gpg
+	helm pull oci://quay.io/jetstack/charts/cert-manager \
+		--version $(CERT_MANAGER_VERSION) \
+		--verify --keyring $(CHART_DIR)/cert-manager-keyring.gpg \
+		--untar --untardir $(CHART_DIR)
 
 setup:
 	aqua i -l

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,4 +1,7 @@
 KUBERNETES_VERSION = v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661 # renovate: kindest/node
+# renovate: datasource=github-releases depName=cert-manager/cert-manager
+CERT_MANAGER_VERSION = v1.20.2
+CERT_MANAGER_SHA256 = 1ce11cae912adecc69e6bb623435fafc9ed21505f9efff98bd71d7b80f01db1f
 
 KUBECTL_ACCURATE := $(dir $(shell pwd))/bin/kubectl-accurate
 KUBECONFIG := $(shell pwd)/.kubeconfig
@@ -22,7 +25,10 @@ start: setup $(KUBECTL_ACCURATE)
 	kind create cluster --name=accurate --config=$(KIND_CONFIG) --image=kindest/node:$(KUBERNETES_VERSION) --wait 1m
 	cd ..; docker build --no-cache -t accurate:dev .
 	kind load docker-image accurate:dev --name=accurate
-	kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
+	curl -fsSL -o cert-manager.yaml https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml
+	echo "$(CERT_MANAGER_SHA256)  cert-manager.yaml" | sha256sum --check
+	kubectl apply -f cert-manager.yaml
+	rm -f cert-manager.yaml
 	kubectl -n cert-manager wait --for=condition=available --timeout=180s --all deployments
 	helm install --create-namespace --namespace accurate accurate ../charts/accurate -f values.yaml
 	kubectl -n accurate wait --for=condition=available --timeout=180s --all deployments

--- a/renovate.json5
+++ b/renovate.json5
@@ -235,5 +235,25 @@
         'KUBERNETES_VERSION := (?<currentValue>.*?) # renovate: kindest\\/node',
       ],
     },
+    {
+      customType: 'regex',
+      datasourceTemplate: 'github-releases',
+      managerFilePatterns: [
+        '/^e2e\\/Makefile$/',
+      ],
+      matchStrings: [
+        '# renovate: datasource=github-releases depName=(?<depName>[^\\s]+)\\nCERT_MANAGER_VERSION = (?<currentValue>v[^\\s]+)',
+      ],
+    },
+    {
+      customType: 'regex',
+      datasourceTemplate: 'github-releases',
+      managerFilePatterns: [
+        '/^\\.github\\/workflows\\/.+\\.ya?ml$/',
+      ],
+      matchStrings: [
+        '# renovate: datasource=github-releases depName=(?<depName>[^\\s]+)\\n\\s+CERT_MANAGER_VERSION: (?<currentValue>v[^\\s]+)',
+      ],
+    },
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -237,22 +237,24 @@
     },
     {
       customType: 'regex',
-      datasourceTemplate: 'github-releases',
+      datasourceTemplate: 'helm',
+      registryUrlTemplate: 'https://charts.jetstack.io',
       managerFilePatterns: [
-        '/^e2e\\/Makefile$/',
+        '/^e2e\/Makefile$/',
       ],
       matchStrings: [
-        '# renovate: datasource=github-releases depName=(?<depName>[^\\s]+)\\nCERT_MANAGER_VERSION = (?<currentValue>v[^\\s]+)',
+        '# renovate: datasource=helm registryUrl=https://charts.jetstack.io depName=(?<depName>[^\\s]+)\\nCERT_MANAGER_VERSION = (?<currentValue>v[^\\s]+)',
       ],
     },
     {
       customType: 'regex',
-      datasourceTemplate: 'github-releases',
+      datasourceTemplate: 'helm',
+      registryUrlTemplate: 'https://charts.jetstack.io',
       managerFilePatterns: [
         '/^\\.github\\/workflows\\/.+\\.ya?ml$/',
       ],
       matchStrings: [
-        '# renovate: datasource=github-releases depName=(?<depName>[^\\s]+)\\n\\s+CERT_MANAGER_VERSION: (?<currentValue>v[^\\s]+)',
+        '# renovate: datasource=helm registryUrl=https://charts.jetstack.io depName=(?<depName>[^\\s]+)\\n\\s+CERT_MANAGER_VERSION: (?<currentValue>v[^\\s]+)',
       ],
     },
   ],


### PR DESCRIPTION
### Overview
add SHA256 checksum verification for cert-manager manifest

Verify the integrity of the downloaded cert-manager.yaml before
applying it to the cluster. This prevents potential supply chain
attacks via a compromised download.

Updated locations:
- .github/workflows/helm.yaml
- e2e/Makefile
- charts/accurate/README.md
- docs/setup.md