### PR TITLE
[CI] Add pinact check for GitHub Actions

### DIFF
--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -1,0 +1,20 @@
+name: Pinact
+on:
+  pull_request:
+    paths:
+      - '.github/**/*.yml'
+      - '.github/**/*.yaml'
+jobs:
+  verify-pinact:
+    name: Verify pinned GitHub Actions comments
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/aqua
+      - name: Verify SHAs and tag comments are consistent
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pinact run --check --verify-comment

--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -181,6 +181,26 @@
       "algorithm": "sha256"
     },
     {
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0/pinact_darwin_amd64.tar.gz",
+      "checksum": "242D0697152D31BF04F3759EC5C55CF8CCBF47B6E2680DD24531E63A6D890468",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0/pinact_darwin_arm64.tar.gz",
+      "checksum": "3260E0D6FA7D89E4B9A7CC6C120345DB9217C4E0571742E9A76DB2BA3FF63650",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0/pinact_linux_amd64.tar.gz",
+      "checksum": "CC220902615325B10BD3BC52ED3DE27488F79ADAEC52ADCD12BD2194C2D2C592",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0/pinact_linux_arm64.tar.gz",
+      "checksum": "C5D8EF4B253A749B754AD04F484D93C78FADE5470BB549D58DF6A8AECA9B18BF",
+      "algorithm": "sha256"
+    },
+    {
       "id": "http/dl.k8s.io/v1.36.1/bin/darwin/amd64/kubectl",
       "checksum": "B4973E90EBB00537D735B63D6F8293C1959156E6FF435F6A43C08AEAA1A2E7D7",
       "algorithm": "sha256"

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -30,3 +30,4 @@ packages:
   - name: kubernetes/code-generator/conversion-gen@v0.36.1
     registry: local
   - name: golangci/golangci-lint@v2.11.4
+  - name: suzuki-shunsuke/pinact@v4.0.0


### PR DESCRIPTION
## Overview:

This PR adds a CI workflow to verify pinned GitHub Actions with pinact.

The workflow checks that GitHub Actions SHAs and their version comments are consistent. 
It also adds pinact to aqua.