### PR TITLE
Update sealed-secrets Helm repository URL

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -33,7 +33,7 @@ start: setup $(KUBECTL_ACCURATE) $(CHART_DIR)/cert-manager/Chart.yaml
 	kubectl -n cert-manager wait --for=condition=available --timeout=180s --all deployments
 	helm install --create-namespace --namespace accurate accurate ../charts/accurate -f values.yaml
 	kubectl -n accurate wait --for=condition=available --timeout=180s --all deployments
-	helm repo add sealed-secrets https://bitnami-labs.github.io/sealed-secrets
+	helm repo add sealed-secrets https://bitnami.github.io/sealed-secrets
 	helm repo update
 	helm install sealed-secrets-controller --namespace kube-system sealed-secrets/sealed-secrets
 	kubectl -n kube-system wait --for=condition=available --timeout=180s --all deployments


### PR DESCRIPTION
sealed-secrets Helm repository URL has changed, causing E2E tests to [fail](https://github.com/cybozu-go/accurate/actions/runs/27588092944/job/81562807685). Therefore, we will update it to the new URL. Please also see https://github.com/bitnami/sealed-secrets/issues/1982.