### PR TITLE
feat: Publish the Helm chart as OCI artifact

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,46 +56,83 @@ jobs:
     if: contains(needs.release.result, 'success')
     permissions:
       contents: write
+      packages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+
       - uses: ./.github/actions/aqua
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
       - name: Set chart version
         run: |
           helm repo add accurate https://cybozu-go.github.io/accurate
           helm repo update
-          
+
           # get the release tag version
           tag_version=${GITHUB_REF##*/v}
-          
+
           # get the latest chart version
           chart_version=$(helm search repo accurate -o json | jq -r 'sort_by(.version) | .[-1].version')
           chart_patch_version=${chart_version##*.}
           new_patch_version=$(($chart_patch_version+1))
-          
+
           # if minor or major version changed, reset new patch version
           local_version=$(cat charts/accurate/Chart.yaml | yq .version | sed "s/0-chart-patch-version-placeholder/$chart_patch_version/g")
           [ "$local_version" != "$chart_version" ] && new_patch_version=0
-          
+
           # replace placeholder with new version
           sed --in-place "s/app-version-placeholder/$tag_version/g" charts/accurate/Chart.yaml
           sed --in-place "s/0-chart-patch-version-placeholder/$new_patch_version/g" charts/accurate/Chart.yaml
           sed --in-place "s/app-version-placeholder/$tag_version/g" charts/accurate/values.yaml
+
       - name: Create release notes
         run: |
           tag_version=${GITHUB_REF##*/}
           cat <<EOF > ./charts/accurate/RELEASE.md
           Helm chart for accurate [$tag_version](https://github.com/cybozu-go/accurate/releases/tag/$tag_version)
-          
+
           EOF
+
+      - name: Login to ghcr.io
+        run: |
+          printf '%s' "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
+          printf '%s' "${{ secrets.GITHUB_TOKEN }}" | cosign login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
+
+      - name: Publish and sign OCI Helm chart
+        run: |
+          mkdir -p .dist
+          chart_ref="ghcr.io/cybozu-go/charts/accurate"
+
+          helm package charts/accurate --destination .dist
+
+          chart_package="$(find .dist -maxdepth 1 -name 'accurate-*.tgz' -print -quit)"
+          test -n "${chart_package}"
+
+          helm push "${chart_package}" oci://ghcr.io/cybozu-go/charts 2>&1 | tee .digest
+
+          digest=$(awk -F "[, ]+" '/Digest/{print $NF}' .digest)
+          test -n "$digest"
+
+          cosign sign --yes \
+            -a "repo=${{ github.repository }}" \
+            -a "workflow=${{ github.workflow }}" \
+            -a "ref=${{ github.sha }}" \
+            -a "kind=helm-chart" \
+            "${chart_ref}@${digest}"
+
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:


### PR DESCRIPTION
I created a test repository to check whether a Helm Chart can be published to an OCI registry.
- https://github.com/ystkfujii/playground_helm_chart

However, I have not actually tested this repository yet, so there may be some issues.

If I find any issues, I will fix them as needed.


Ref: https://github.com/cybozu-go/accurate/issues/157
