### PR TITLE
ci: Switch chart version resolution to OCI registry via oras

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -129,3 +129,13 @@ jobs:
             -a "ref=${{ github.sha }}" \
             -a "kind=helm-chart" \
             "${chart_ref}@${digest}"
+
+      - name: Publish Artifact Hub repository metadata
+        run: |
+          set -euo pipefail
+
+          chart_ref="ghcr.io/cybozu-go/charts/accurate"
+
+          oras push "${chart_ref}:artifacthub.io" \
+            --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+            artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
     needs: release
     if: contains(needs.release.result, 'success')
     permissions:
-      contents: write
+      contents: read
       packages: write
       id-token: write
     steps:
@@ -67,20 +67,27 @@ jobs:
       - uses: ./.github/actions/aqua
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      
+      - name: Login to ghcr.io
+        run: |
+          printf '%s' "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
+          printf '%s' "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
+          printf '%s' "${{ secrets.GITHUB_TOKEN }}" | cosign login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
 
       - name: Set chart version
-        run: |
-          helm repo add accurate https://cybozu-go.github.io/accurate
-          helm repo update
-
+        run: |          
+          oras repo tags "ghcr.io/cybozu-go/charts/accurate" --exclude-digest-tags --format json > .oci-tags.json
+          
           # get the release tag version
           tag_version=${GITHUB_REF##*/v}
 
           # get the latest chart version
-          chart_version=$(helm search repo accurate -o json | jq -r 'sort_by(.version) | .[-1].version')
+          chart_version="$(
+            jq -r '.tags[]?' .oci-tags.json |
+              grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' |
+              sort -V |
+              tail -n 1 || true
+          )"
           chart_patch_version=${chart_version##*.}
           new_patch_version=$(($chart_patch_version+1))
 
@@ -93,18 +100,13 @@ jobs:
           sed --in-place "s/0-chart-patch-version-placeholder/$new_patch_version/g" charts/accurate/Chart.yaml
           sed --in-place "s/app-version-placeholder/$tag_version/g" charts/accurate/values.yaml
 
-      - name: Create release notes
+      - name: Create chart release notes
         run: |
           tag_version=${GITHUB_REF##*/}
           cat <<EOF > ./charts/accurate/RELEASE.md
           Helm chart for accurate [$tag_version](https://github.com/cybozu-go/accurate/releases/tag/$tag_version)
 
           EOF
-
-      - name: Login to ghcr.io
-        run: |
-          printf '%s' "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
-          printf '%s' "${{ secrets.GITHUB_TOKEN }}" | cosign login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
 
       - name: Publish and sign OCI Helm chart
         run: |
@@ -127,15 +129,3 @@ jobs:
             -a "ref=${{ github.sha }}" \
             -a "kind=helm-chart" \
             "${chart_ref}@${digest}"
-
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
-        with:
-          config: cr.yaml
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -246,6 +246,26 @@
       "algorithm": "sha256"
     },
     {
+      "id": "github_release/github.com/oras-project/oras/v1.3.2/oras_1.3.2_darwin_amd64.tar.gz",
+      "checksum": "2621F6B252B222F6FBF4E114D2FCAA0CEC6B632624FFAF73143F66E4E0994F86",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/oras-project/oras/v1.3.2/oras_1.3.2_darwin_arm64.tar.gz",
+      "checksum": "7929F792CF272268412375ECAD6F0FB3C20F164368D5B57966E67AD6D36ECA53",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/oras-project/oras/v1.3.2/oras_1.3.2_linux_amd64.tar.gz",
+      "checksum": "9229CCC6D17BB282039AD4A69ABB16DCB887A5BCE567C075D731D9B3C7AD8EAF",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/oras-project/oras/v1.3.2/oras_1.3.2_linux_arm64.tar.gz",
+      "checksum": "8DB4A223BD6034DEFF198E791EA7CB3AF0840DF25B7E9F370E2F1F3FD20D389B",
+      "algorithm": "sha256"
+    },
+    {
       "id": "github_release/github.com/rust-lang/mdBook/v0.5.2/mdbook-v0.5.2-x86_64-apple-darwin.tar.gz",
       "checksum": "17CC64478EC279A73881420E850BD8F9D460552E56B50159FF465BC97EB90D6C",
       "algorithm": "sha256"
@@ -253,6 +273,36 @@
     {
       "id": "github_release/github.com/rust-lang/mdBook/v0.5.2/mdbook-v0.5.2-x86_64-unknown-linux-musl.tar.gz",
       "checksum": "8E9D802BBECEA34380AABFC65BEC4FDBA23C07453EF2C7E06FA34C282082E2C4",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/rust-lang/mdBook/v0.5.3/mdbook-v0.5.3-x86_64-apple-darwin.tar.gz",
+      "checksum": "9B74591168F8DBF19FCDF2386B68031FECC4B847B2E81E2DE2D23ED502618875",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/rust-lang/mdBook/v0.5.3/mdbook-v0.5.3-x86_64-unknown-linux-musl.tar.gz",
+      "checksum": "DFB86D8E20A3FED91BF549AA450B9D7F46A275B700292E050CDFD3171732E7FD",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/sigstore/cosign/v3.1.1/cosign-darwin-amd64",
+      "checksum": "14D2678DFBFDE18798151E86FBD91EBDADBB7424B18412A42A155DD8A2DF4C7A",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/sigstore/cosign/v3.1.1/cosign-darwin-arm64",
+      "checksum": "94B42A9E697BE95675F6160AB031A9A5F1EC1E646D6F648D7B2F5CD59ECECBC5",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/sigstore/cosign/v3.1.1/cosign-linux-amd64",
+      "checksum": "AE1ECD212663F3693AD9EDF8B1A183900C9A52D3155BA6E354237F9A0F6463FC",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/sigstore/cosign/v3.1.1/cosign-linux-arm64",
+      "checksum": "2EC865872E331C32FD12B08DAE15332D3F92C0AA029219589684A4903CA85D11",
       "algorithm": "sha256"
     },
     {
@@ -273,16 +323,6 @@
     {
       "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0/pinact_linux_arm64.tar.gz",
       "checksum": "C5D8EF4B253A749B754AD04F484D93C78FADE5470BB549D58DF6A8AECA9B18BF",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/rust-lang/mdBook/v0.5.3/mdbook-v0.5.3-x86_64-apple-darwin.tar.gz",
-      "checksum": "9B74591168F8DBF19FCDF2386B68031FECC4B847B2E81E2DE2D23ED502618875",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/rust-lang/mdBook/v0.5.3/mdbook-v0.5.3-x86_64-unknown-linux-musl.tar.gz",
-      "checksum": "DFB86D8E20A3FED91BF549AA450B9D7F46A275B700292E050CDFD3171732E7FD",
       "algorithm": "sha256"
     },
     {

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -31,3 +31,5 @@ packages:
     registry: local
   - name: golangci/golangci-lint@v2.12.2
   - name: suzuki-shunsuke/pinact@v4.0.0
+  - name: oras-project/oras@v1.3.2
+  - name: sigstore/cosign@v3.1.1

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,1 @@
+repositoryID: c9a0512a-0dd7-4353-ac66-fcac544e9ab3

--- a/charts/accurate/MIGRATION.md
+++ b/charts/accurate/MIGRATION.md
@@ -9,9 +9,7 @@ There is no significant difference between the manifests installed by kustomize 
 If a resource with the same name already exists in the Cluster, Helm will not be able to create the resource.
 
 ```console
-$ helm repo add accurate https://cybozu-go.github.io/accurate/
-$ helm repo update
-$ helm install --namespace accurate accurate accurate/accurate
+$ helm install --namespace accurate accurate oci://ghcr.io/cybozu-go/charts/accurate
 Error: rendered manifests contain a resource that already exists. Unable to continue with install: ServiceAccount "accurate-controller-manager" in namespace "accurate" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "accurate"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "accurate"
 ```
 
@@ -19,7 +17,7 @@ Before installing Helm chart, you need to manually delete the resources.
 You do not need to delete Namespace, CRD and SubNamespace custom resources at this time.
 
 ```console
-$ helm template --namespace accurate accurate accurate/accurate | kubectl delete -f -
+$ helm template --namespace accurate accurate oci://ghcr.io/cybozu-go/charts/accurate | kubectl delete -f -
 serviceaccount "accurate-controller-manager" deleted
 clusterrole.rbac.authorization.k8s.io "accurate-manager-role" deleted
 clusterrole.rbac.authorization.k8s.io "accurate-subnamespace-editor-role" deleted
@@ -40,7 +38,7 @@ Error from server (NotFound): error when deleting "STDIN": configmaps "accurate-
 Then install Helm chart again.
 
 ```console
-$ helm install --namespace accurate accurate accurate/accurate
+$ helm install --namespace accurate accurate oci://ghcr.io/cybozu-go/charts/accurate
 NAME: accurate
 LAST DEPLOYED: Fri Aug 20 10:12:03 2021
 NAMESPACE: accurate
@@ -122,7 +120,7 @@ controller:
 The values file can be specified with the `-f` option when you install Helm chart.
 
 ```bash
-helm install --create-namespace --namespace accurate accurate accurate/accurate -f values.yaml
+helm install --create-namespace --namespace accurate accurate oci://ghcr.io/cybozu-go/charts/accurate -f values.yaml
 ```
 
 There are several other configurable items besides the Accurate config file. See [README.md](./README.md) for details.

--- a/charts/accurate/README.md
+++ b/charts/accurate/README.md
@@ -96,6 +96,7 @@ Charts older than v0.7.13 are not available in the OCI registry.
 To find older versions, use the legacy Helm chart repository:
 
 ```bash
-helm repo add accurate https://cybozu-go.github.io/accurate
+helm repo add accurate https://cybozu-go.github.io/accurate/
+helm repo update
 helm search repo accurate/accurate --versions
 ```

--- a/charts/accurate/README.md
+++ b/charts/accurate/README.md
@@ -1,13 +1,7 @@
 # Accurate Helm Chart
 
-## How to use Accurate Helm repository
-
-You need to add this repository to your Helm repositories:
-
-```bash
-helm repo add accurate https://cybozu-go.github.io/accurate/
-helm repo update
-```
+The Accurate Helm chart is published to an OCI registry at `oci://ghcr.io/cybozu-go/charts/accurate`.
+There is no need to add a Helm repository; the chart can be referenced directly by its OCI URL.
 
 ## Quick start
 
@@ -55,7 +49,7 @@ If you decided to manage CRDs outside of Helm, make sure you set the `crds.enabl
 To install the chart with the release name `accurate` using a dedicated namespace(recommended):
 
 ```bash
-helm install --create-namespace --namespace accurate accurate accurate/accurate
+helm install --create-namespace --namespace accurate accurate oci://ghcr.io/cybozu-go/charts/accurate
 ```
 
 Specify parameters using `--set key=value[,key=value]` argument to `helm install`.
@@ -63,7 +57,7 @@ Specify parameters using `--set key=value[,key=value]` argument to `helm install
 Alternatively a YAML file that specifies the values for the parameters can be provided like this:
 
 ```bash
-helm install --create-namespace --namespace accurate accurate -f values.yaml accurate/accurate
+helm install --create-namespace --namespace accurate accurate -f values.yaml oci://ghcr.io/cybozu-go/charts/accurate
 ```
 
 ## Values
@@ -93,5 +87,15 @@ helm install --create-namespace --namespace accurate accurate -f values.yaml acc
 You can use the `helm template` command to render manifests.
 
 ```bash
-helm template --namespace accurate accurate accurate/accurate
+helm template --namespace accurate accurate oci://ghcr.io/cybozu-go/charts/accurate
+```
+
+## Older chart versions
+
+Charts older than v0.7.13 are not available in the OCI registry.
+To find older versions, use the legacy Helm chart repository:
+
+```bash
+helm repo add accurate https://cybozu-go.github.io/accurate
+helm search repo accurate/accurate --versions
 ```

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,5 +1,0 @@
-owner: cybozu-go
-git-repo: accurate
-release-name-template: "{{ .Name }}-chart-{{ .Version }}"
-make-release-latest: false
-release-notes-file: RELEASE.md

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -18,21 +18,16 @@
     rm -rf cert-manager-keyring.gpg ./cert-manager-chart
     ```
 
-2. Setup Accurate Helm repository
-
-   ```bash
-   helm repo add accurate https://cybozu-go.github.io/accurate/
-   helm repo update
-   ```
-
-3. Configuration Helm chart values
+2. Configuration Helm chart values
 
     Read [Configurations](config.md) for details.
 
-4. Install the Accurate Helm chart
+3. Install the Accurate Helm chart
+
+    The Accurate Helm chart is published to an OCI registry, so it can be installed directly by its OCI URL.
 
     ```bash
-    helm install --create-namespace --namespace accurate accurate accurate/accurate -f values.yaml
+    helm install --create-namespace --namespace accurate accurate oci://ghcr.io/cybozu-go/charts/accurate -f values.yaml
     ```
 
 [cert-manager]: https://cert-manager.io/

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -18,7 +18,7 @@
     rm -rf cert-manager-keyring.gpg ./cert-manager-chart
     ```
 
-2. Configuration Helm chart values
+2. Configure Helm chart values
 
     Read [Configurations](config.md) for details.
 


### PR DESCRIPTION
This PR updates the Helm chart release workflow to use the OCI registry on GHCR.

The release workflow now resolves the latest chart version from OCI tags using oras, publishes Artifact Hub metadata as an OCI artifact, and no longer uses chart-releaser.

Ref: https://github.com/cybozu-go/accurate/issues/173
Ref: https://github.com/cybozu-go/accurate/issues/61